### PR TITLE
Handle missing Nexa dependency

### DIFF
--- a/main.py
+++ b/main.py
@@ -24,7 +24,12 @@ from image_data_processing import (
 )
 
 from output_filter import filter_specific_output  # Import the context manager
-from nexa.gguf import NexaVLMInference, NexaTextInference  # Import model classes
+try:
+    from nexa.gguf import NexaVLMInference, NexaTextInference  # Import model classes
+except ModuleNotFoundError as exc:
+    raise ModuleNotFoundError(
+        "Не найден модуль 'nexa'. Установите пакет 'nexaai' согласно инструкции в README.md"
+    ) from exc
 
 def ensure_nltk_data():
     """Ensure that NLTK data is downloaded efficiently and quietly."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ xlrd
 nltk
 rich
 python-pptx
+nexaai


### PR DESCRIPTION
## Summary
- add helpful error when Nexa module is missing
- include nexaai in requirements

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68a7786f65188330b08ceb70d3bba402