### PR TITLE
Add config and OpenRouter env loader

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,0 +1,12 @@
+categories:
+  - Receipts
+  - Insurance
+  - School
+people:
+  - Alice
+  - Bob
+  - Charlie
+vendors:
+  - Amazon
+  - IKEA
+  - Zalando

--- a/config_loader.py
+++ b/config_loader.py
@@ -1,0 +1,17 @@
+import os
+from dotenv import load_dotenv
+import yaml
+
+
+def load_config(config_path: str = "config.yml"):
+    """Load application configuration from a YAML file."""
+    with open(config_path, "r", encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def load_openrouter_settings():
+    """Load OpenRouter API key and model from environment variables."""
+    load_dotenv()
+    api_key = os.getenv("OPENROUTER_API_KEY")
+    model = os.getenv("OPENROUTER_MODEL")
+    return {"api_key": api_key, "model": model}

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,6 @@ xlrd
 nltk
 rich
 python-pptx
+
+python-dotenv
+PyYAML


### PR DESCRIPTION
## Summary
- add configurable category, people and vendor lists
- add config utilities to load YAML settings and OpenRouter creds
- include python-dotenv and PyYAML requirements

## Testing
- `python -m py_compile config_loader.py`
- `pip install python-dotenv PyYAML` *(fails: Could not find a version that satisfies the requirement python-dotenv)*

------
https://chatgpt.com/codex/tasks/task_e_68a77d75668883309d42ff5968661bc2