### PR TITLE
Add OCR and metadata extraction with LLM placeholder

### DIFF
--- a/analysis_module.py
+++ b/analysis_module.py
@@ -1,0 +1,28 @@
+"""LLM analysis module.
+
+Этот модуль предоставляет функцию-обёртку для анализа текста при
+помощи LLM. В текущей версии используется заглушка, которую при
+необходимости можно заменить реальным вызовом к OpenRouter или другой
+службе ИИ.
+"""
+
+from __future__ import annotations
+
+from typing import Dict
+
+
+def analyze_text_with_llm(text: str) -> Dict[str, str]:
+    """Отправляет текст в LLM и возвращает результаты анализа.
+
+    Поскольку в тестовой среде отсутствует доступ к внешним сервисам,
+    функция возвращает простую заглушку. При интеграции с реальным LLM
+    сюда следует добавить обращение к API и обработку ответа.
+    """
+
+    # TODO: Replace with real LLM integration.
+    summary = text.strip()[:100]
+    return {"summary": summary}
+
+
+__all__ = ["analyze_text_with_llm"]
+

--- a/data_processing_common.py
+++ b/data_processing_common.py
@@ -32,6 +32,16 @@ def sanitize_filename(name, max_length=50, max_words=5):
     # Limit length
     return limited_name[:max_length] if limited_name else 'untitled'
 
+
+def extract_file_metadata(file_path):
+    """Извлечь основные метаданные файла."""
+    stats = os.stat(file_path)
+    return {
+        "size": stats.st_size,
+        "created": datetime.datetime.fromtimestamp(stats.st_ctime).isoformat(),
+        "modified": datetime.datetime.fromtimestamp(stats.st_mtime).isoformat(),
+    }
+
 def process_files_by_date(file_paths, output_path, dry_run=False, silent=False, log_file=None):
     """Process files to organize them by date."""
     operations = []

--- a/text_data_processing.py
+++ b/text_data_processing.py
@@ -5,7 +5,8 @@ from nltk.tokenize import word_tokenize, sent_tokenize
 from nltk.corpus import stopwords
 from nltk.stem import WordNetLemmatizer
 from rich.progress import Progress, TextColumn, BarColumn, TimeElapsedColumn
-from data_processing_common import sanitize_filename
+from data_processing_common import sanitize_filename, extract_file_metadata
+from analysis_module import analyze_text_with_llm
 
 
 def summarize_text_content(text):
@@ -22,6 +23,10 @@ def process_single_text_file(args, silent=False, log_file=None):
     file_path, text = args
     start_time = time.time()
 
+    # Analyze text with LLM and gather metadata
+    analysis = analyze_text_with_llm(text)
+    metadata = extract_file_metadata(file_path)
+
     # Create a Progress instance for this file
     with Progress(
         TextColumn("[progress.description]{task.description}"),
@@ -34,7 +39,13 @@ def process_single_text_file(args, silent=False, log_file=None):
     end_time = time.time()
     time_taken = end_time - start_time
 
-    message = f"File: {file_path}\nTime taken: {time_taken:.2f} seconds\nDescription: {description}\nFolder name: {foldername}\nGenerated filename: {filename}\n"
+    message = (
+        f"File: {file_path}\nTime taken: {time_taken:.2f} seconds\n"
+        f"Description: {description}\nFolder name: {foldername}\n"
+        f"Generated filename: {filename}\n"
+        f"Metadata: {metadata}\n"
+        f"Analysis: {analysis}\n"
+    )
     if silent:
         if log_file:
             with open(log_file, 'a') as f:
@@ -45,7 +56,9 @@ def process_single_text_file(args, silent=False, log_file=None):
         'file_path': file_path,
         'foldername': foldername,
         'filename': filename,
-        'description': description
+        'description': description,
+        'analysis': analysis,
+        'metadata': metadata,
     }
 
 def process_text_files(text_tuples, silent=False, log_file=None):


### PR DESCRIPTION
## Summary
- add placeholder module for LLM text analysis
- extract basic file metadata
- use pytesseract to OCR images and send text to analysis
- forward text data to analysis module

## Testing
- `python -m py_compile analysis_module.py data_processing_common.py image_data_processing.py text_data_processing.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a77d6b0b68833099a43c76df3e7477