### PR TITLE
feat: integrate OpenRouter metadata extraction

### DIFF
--- a/openrouter_client.py
+++ b/openrouter_client.py
@@ -1,0 +1,68 @@
+import os
+import time
+import json
+import requests
+
+OPENROUTER_API_URL = "https://openrouter.ai/api/v1/chat/completions"
+EXPECTED_FIELDS = [
+    "category",
+    "subcategory",
+    "date",
+    "issuer",
+    "person",
+    "document_type",
+    "amount",
+    "tags",
+    "suggested_filename",
+    "note",
+]
+
+def fetch_metadata_from_llm(text, max_retries=3):
+    """Send text to OpenRouter LLM and parse structured JSON response.
+
+    Retries the request if the model returns invalid JSON.
+    """
+    api_key = os.getenv("OPENROUTER_API_KEY")
+    model = os.getenv("OPENROUTER_MODEL", "openrouter/llama3-8b")
+    if not api_key:
+        raise RuntimeError("OPENROUTER_API_KEY is not set")
+
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+    system_prompt = (
+        "You extract metadata from documents. Respond with JSON containing the keys: "
+        "category, subcategory, date, issuer, person, document_type, amount, tags, "
+        "suggested_filename, note. Use empty strings or an empty list where data is missing."
+    )
+
+    payload = {
+        "model": model,
+        "messages": [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": text},
+        ],
+    }
+
+    for attempt in range(max_retries):
+        response = requests.post(OPENROUTER_API_URL, headers=headers, json=payload, timeout=30)
+        response.raise_for_status()
+        try:
+            content = response.json()["choices"][0]["message"]["content"].strip()
+            if content.startswith("```"):
+                parts = content.split("```", 2)
+                if len(parts) >= 2:
+                    content = parts[1]
+                    if content.startswith("json"):
+                        content = content[4:]
+                    content = content.strip()
+            data = json.loads(content)
+            for field in EXPECTED_FIELDS:
+                if field not in data:
+                    data[field] = [] if field == "tags" else ""
+            return data
+        except Exception:
+            if attempt == max_retries - 1:
+                raise
+            time.sleep(1)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ xlrd
 nltk
 rich
 python-pptx
+requests

--- a/text_data_processing.py
+++ b/text_data_processing.py
@@ -1,21 +1,8 @@
-import re
 import os
 import time
-from nltk.tokenize import word_tokenize, sent_tokenize
-from nltk.corpus import stopwords
-from nltk.stem import WordNetLemmatizer
 from rich.progress import Progress, TextColumn, BarColumn, TimeElapsedColumn
 from data_processing_common import sanitize_filename
-
-
-def summarize_text_content(text):
-    """Summarize the given text content using simple heuristics."""
-    sentences = sent_tokenize(text)
-    summary = " ".join(sentences[:3])
-    words = summary.split()
-    if len(words) > 150:
-        summary = " ".join(words[:150])
-    return summary
+from openrouter_client import fetch_metadata_from_llm
 
 def process_single_text_file(args, silent=False, log_file=None):
     """Process a single text file to generate metadata."""
@@ -29,12 +16,15 @@ def process_single_text_file(args, silent=False, log_file=None):
         TimeElapsedColumn()
     ) as progress:
         task_id = progress.add_task(f"Processing {os.path.basename(file_path)}", total=1.0)
-        foldername, filename, description = generate_text_metadata(text, file_path, progress, task_id)
+        foldername, filename, description, metadata = generate_text_metadata(text, file_path, progress, task_id)
 
     end_time = time.time()
     time_taken = end_time - start_time
 
-    message = f"File: {file_path}\nTime taken: {time_taken:.2f} seconds\nDescription: {description}\nFolder name: {foldername}\nGenerated filename: {filename}\n"
+    message = (
+        f"File: {file_path}\nTime taken: {time_taken:.2f} seconds\n"
+        f"Description: {description}\nFolder name: {foldername}\nGenerated filename: {filename}\n"
+    )
     if silent:
         if log_file:
             with open(log_file, 'a') as f:
@@ -45,7 +35,8 @@ def process_single_text_file(args, silent=False, log_file=None):
         'file_path': file_path,
         'foldername': foldername,
         'filename': filename,
-        'description': description
+        'description': description,
+        'metadata': metadata,
     }
 
 def process_text_files(text_tuples, silent=False, log_file=None):
@@ -57,64 +48,34 @@ def process_text_files(text_tuples, silent=False, log_file=None):
     return results
 
 def generate_text_metadata(input_text, file_path, progress, task_id):
-    """Generate description, folder name, and filename for a text document."""
+    """Generate description, folder name, and filename for a text document using LLM."""
 
-    # Total steps in processing a text file
-    total_steps = 3
+    # Total steps: 2 (LLM call and sanitization)
+    total_steps = 2
 
-    # Step 1: Generate description
-    description = summarize_text_content(input_text)
+    try:
+        metadata = fetch_metadata_from_llm(input_text)
+    except Exception:
+        metadata = {field: '' for field in ['category', 'subcategory', 'issuer', 'person', 'suggested_filename', 'note']}
+        metadata['category'] = 'Unsorted'
     progress.update(task_id, advance=1 / total_steps)
 
-    # Remove unwanted words and stopwords
-    unwanted_words = set([
-        'the', 'and', 'based', 'generated', 'this', 'is', 'filename', 'file', 'document', 'text', 'output', 'only', 'below', 'category',
-        'summary', 'key', 'details', 'information', 'note', 'notes', 'main', 'ideas', 'concepts', 'in', 'on', 'of', 'with', 'by', 'for',
-        'to', 'from', 'a', 'an', 'as', 'at', 'i', 'we', 'you', 'they', 'he', 'she', 'it', 'that', 'which', 'are', 'were', 'was', 'be',
-        'have', 'has', 'had', 'do', 'does', 'did', 'but', 'if', 'or', 'because', 'about', 'into', 'through', 'during', 'before', 'after',
-        'above', 'below', 'any', 'each', 'few', 'more', 'most', 'other', 'some', 'such', 'no', 'nor', 'not', 'only', 'own', 'same', 'so',
-        'than', 'too', 'very', 's', 't', 'can', 'will', 'just', 'don', 'should', 'now', 'new', 'depicts', 'show', 'shows', 'display',
-        'illustrates', 'presents', 'features', 'provides', 'covers', 'includes', 'discusses', 'demonstrates', 'describes'
-    ])
-    stop_words = set(stopwords.words('english'))
-    all_unwanted_words = unwanted_words.union(stop_words)
-    lemmatizer = WordNetLemmatizer()
+    # Build folder structure
+    parts = [
+        metadata.get('category', ''),
+        metadata.get('subcategory', ''),
+        metadata.get('person') or metadata.get('issuer', ''),
+    ]
+    parts = [sanitize_filename(p, max_words=2) for p in parts if p]
+    foldername = os.path.join(*parts) if parts else 'Unsorted'
 
-    # Function to clean and process text
-    def clean_text(text, max_words):
-        # Remove special characters and numbers
-        text = re.sub(r'[^\w\s]', ' ', text)
-        text = re.sub(r'\d+', '', text)
-        text = text.strip()
-        # Split concatenated words (e.g., 'mathOperations' -> 'math Operations')
-        text = re.sub(r'([a-z])([A-Z])', r'\1 \2', text)
-        # Tokenize and lemmatize words
-        words = word_tokenize(text)
-        words = [word.lower() for word in words if word.isalpha()]
-        words = [lemmatizer.lemmatize(word) for word in words]
-        # Remove unwanted words and duplicates
-        filtered_words = []
-        seen = set()
-        for word in words:
-            if word not in all_unwanted_words and word not in seen:
-                filtered_words.append(word)
-                seen.add(word)
-        # Limit to max words
-        filtered_words = filtered_words[:max_words]
-        return '_'.join(filtered_words)
+    # Build filename
+    suggested = metadata.get('suggested_filename')
+    if not suggested:
+        suggested = os.path.splitext(os.path.basename(file_path))[0]
+    filename = sanitize_filename(suggested, max_words=3)
 
-    # Step 2: Generate filename
-    filename = clean_text(description, max_words=3)
-    if not filename:
-        filename = 'document_' + os.path.splitext(os.path.basename(file_path))[0]
-    sanitized_filename = sanitize_filename(filename, max_words=3)
+    description = metadata.get('note', '')
     progress.update(task_id, advance=1 / total_steps)
 
-    # Step 3: Generate folder name from summary
-    foldername = clean_text(description, max_words=2)
-    if not foldername:
-        foldername = 'documents'
-    sanitized_foldername = sanitize_filename(foldername, max_words=2)
-    progress.update(task_id, advance=1 / total_steps)
-
-    return sanitized_foldername, sanitized_filename, description
+    return foldername, filename, description, metadata


### PR DESCRIPTION
## Summary
- add OpenRouter client to extract structured metadata from text
- process text files via LLM output, falling back to `Unsorted` on errors
- include `requests` dependency

## Testing
- `python -m py_compile openrouter_client.py text_data_processing.py`


------
https://chatgpt.com/codex/tasks/task_e_68a77d6d64f48330865572972f9d700b