### PR TITLE
Очистка зависимостей и упрощение генерации метаданных

### DIFF
--- a/image_data_processing.py
+++ b/image_data_processing.py
@@ -1,17 +1,11 @@
 import os
-import re
 import time
 from PIL import Image
 import pytesseract
-from nltk.tokenize import word_tokenize
-from nltk.corpus import stopwords
-from nltk.stem import WordNetLemmatizer
 from rich.progress import Progress, TextColumn, BarColumn, TimeElapsedColumn
 
-from data_processing_common import sanitize_filename  # Import sanitize_filename
-from error_handling import handle_model_error
-
 from data_processing_common import sanitize_filename, extract_file_metadata
+from error_handling import handle_model_error
 from analysis_module import analyze_text_with_llm
 
 
@@ -82,65 +76,14 @@ def process_image_files(image_paths, silent=False, log_file=None):
 
 
 def generate_image_metadata(image_path, progress, task_id):
-    """Generate description, folder name, and filename for an image file."""
+    """Placeholder wrapper for OCR/LLM-based metadata generation."""
 
-    # Total steps in processing an image
-    total_steps = 3
+    # Future implementation: use OCR text and an LLM to derive these values.
+    progress.update(task_id, advance=1)
 
-    # Step 1: Generate description using file name
     base_name = os.path.splitext(os.path.basename(image_path))[0]
-    description = base_name.replace('_', ' ')
-    progress.update(task_id, advance=1 / total_steps)
+    filename = sanitize_filename(base_name, max_words=3)
+    foldername = "images"
+    description = ""
 
-    # Remove any unwanted words and stopwords
-    unwanted_words = set([
-        'the', 'and', 'based', 'generated', 'this', 'is', 'filename', 'file', 'image', 'picture', 'photo',
-        'folder', 'category', 'output', 'only', 'below', 'text', 'jpg', 'png', 'jpeg', 'gif', 'bmp', 'svg',
-        'logo', 'in', 'on', 'of', 'with', 'by', 'for', 'to', 'from', 'a', 'an', 'as', 'at', 'red', 'blue',
-        'green', 'color', 'colors', 'colored', 'text', 'graphic', 'graphics', 'main', 'subject', 'important',
-        'details', 'description', 'depicts', 'show', 'shows', 'display', 'illustrates', 'presents', 'features',
-        'provides', 'covers', 'includes', 'demonstrates', 'describes'
-    ])
-    stop_words = set(stopwords.words('english'))
-    all_unwanted_words = unwanted_words.union(stop_words)
-    lemmatizer = WordNetLemmatizer()
-
-    # Function to clean and process text
-    def clean_text(text, max_words):
-        # Remove file extensions and special characters
-        text = re.sub(r'\.\w{1,4}$', '', text)  # Remove file extensions like .jpg, .png
-        text = re.sub(r'[^\w\s]', ' ', text)  # Remove special characters
-        text = re.sub(r'\d+', '', text)  # Remove digits
-        text = text.strip()
-        # Split concatenated words (e.g., 'GoogleChrome' -> 'Google Chrome')
-        text = re.sub(r'([a-z])([A-Z])', r'\1 \2', text)
-        # Tokenize and lemmatize words
-        words = word_tokenize(text)
-        words = [word.lower() for word in words if word.isalpha()]
-        words = [lemmatizer.lemmatize(word) for word in words]
-        # Remove unwanted words and duplicates
-        filtered_words = []
-        seen = set()
-        for word in words:
-            if word not in all_unwanted_words and word not in seen:
-                filtered_words.append(word)
-                seen.add(word)
-        # Limit to max words
-        filtered_words = filtered_words[:max_words]
-        return '_'.join(filtered_words)
-
-    # Step 2: Generate filename
-    filename = clean_text(base_name, max_words=3)
-    if not filename:
-        filename = 'image_' + base_name
-    sanitized_filename = sanitize_filename(filename, max_words=3)
-    progress.update(task_id, advance=1 / total_steps)
-
-    # Step 3: Generate folder name
-    foldername = clean_text(base_name, max_words=2)
-    if not foldername:
-        foldername = 'images'
-    sanitized_foldername = sanitize_filename(foldername, max_words=2)
-    progress.update(task_id, advance=1 / total_steps)
-
-    return sanitized_foldername, sanitized_filename, description
+    return foldername, filename, description

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,7 @@
-cmake
 pytesseract
 PyMuPDF
 python-docx
 pandas
-openpyxl
-xlrd
-nltk
 rich
 python-pptx
 aiohttp


### PR DESCRIPTION
## Summary
- remove NLTK-based processing and replace image metadata generation with a simple OCR/LLM stub
- simplify text metadata generation to rely solely on LLM output
- trim requirements to only necessary packages

## Testing
- `python -m py_compile image_data_processing.py text_data_processing.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a7803609008330ae7dd78cffb9e226