### PR TITLE
Refactor logging and remove unused dependencies

### DIFF
--- a/data_processing_common.py
+++ b/data_processing_common.py
@@ -1,7 +1,10 @@
 import os
 import re
 import datetime  # Import datetime for date operations
+import logging
 from rich.progress import Progress, TextColumn, BarColumn, TimeElapsedColumn
+
+logger = logging.getLogger(__name__)
 
 def sanitize_filename(name, max_length=50, max_words=5):
     """Sanitize the filename by removing unwanted words and characters."""
@@ -211,4 +214,4 @@ def execute_operations(operations, dry_run=False, silent=False, log_file=None):
                     with open(log_file, 'a') as f:
                         f.write(message + '\n')
             else:
-                print(message)
+                logger.info(message)

--- a/file_utils.py
+++ b/file_utils.py
@@ -2,12 +2,15 @@ import os
 import re
 import shutil
 import json
+import logging
 from PIL import Image
 import pytesseract
 import fitz  # PyMuPDF
 import docx
 import pandas as pd  # Import pandas to read Excel and CSV files
 from pptx import Presentation  # Import Presentation for PPT files
+
+logger = logging.getLogger(__name__)
 
 def read_text_file(file_path):
     """Read text content from a text file."""
@@ -17,7 +20,7 @@ def read_text_file(file_path):
             text = file.read(max_chars)
         return text
     except Exception as e:
-        print(f"Error reading text file {file_path}: {e}")
+        logger.error("Error reading text file %s: %s", file_path, e)
         return None
 
 def read_docx_file(file_path):
@@ -27,7 +30,7 @@ def read_docx_file(file_path):
         full_text = [para.text for para in doc.paragraphs]
         return '\n'.join(full_text)
     except Exception as e:
-        print(f"Error reading DOCX file {file_path}: {e}")
+        logger.error("Error reading DOCX file %s: %s", file_path, e)
         return None
 
 def read_pdf_file(file_path):
@@ -43,7 +46,7 @@ def read_pdf_file(file_path):
         pdf_content = '\n'.join(full_text)
         return pdf_content
     except Exception as e:
-        print(f"Error reading PDF file {file_path}: {e}")
+        logger.error("Error reading PDF file %s: %s", file_path, e)
         return None
 
 def read_spreadsheet_file(file_path):
@@ -56,7 +59,7 @@ def read_spreadsheet_file(file_path):
         text = df.to_string()
         return text
     except Exception as e:
-        print(f"Error reading spreadsheet file {file_path}: {e}")
+        logger.error("Error reading spreadsheet file %s: %s", file_path, e)
         return None
 
 def read_ppt_file(file_path):
@@ -70,7 +73,7 @@ def read_ppt_file(file_path):
                     full_text.append(shape.text)
         return '\n'.join(full_text)
     except Exception as e:
-        print(f"Error reading PowerPoint file {file_path}: {e}")
+        logger.error("Error reading PowerPoint file %s: %s", file_path, e)
         return None
 
 def read_file_data(file_path):
@@ -88,23 +91,6 @@ def read_file_data(file_path):
         return read_ppt_file(file_path)
     else:
         return None  # Unsupported file type
-
-def display_directory_tree(path):
-    """Display the directory tree in a format similar to the 'tree' command, including the full path."""
-    def tree(dir_path, prefix=''):
-        contents = sorted([c for c in os.listdir(dir_path) if not c.startswith('.')])
-        pointers = ['├── '] * (len(contents) - 1) + ['└── '] if contents else []
-        for pointer, name in zip(pointers, contents):
-            full_path = os.path.join(dir_path, name)
-            print(prefix + pointer + name)
-            if os.path.isdir(full_path):
-                extension = '│   ' if pointer == '├── ' else '    '
-                tree(full_path, prefix + extension)
-    if os.path.isdir(path):
-        print(os.path.abspath(path))
-        tree(path)
-    else:
-        print(os.path.abspath(path))
 
 def collect_file_paths(base_path):
     """Collect all file paths from the base directory or single file, excluding hidden files."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,9 @@
-cmake
 pytesseract
 PyMuPDF
 python-docx
 pandas
 openpyxl
 xlrd
-nltk
 rich
 python-pptx
 aiohttp

--- a/text_data_processing.py
+++ b/text_data_processing.py
@@ -1,5 +1,6 @@
 import os
 import time
+import logging
 from rich.progress import Progress, TextColumn, BarColumn, TimeElapsedColumn
 
 # --- imports из обеих веток
@@ -21,6 +22,8 @@ API_KEY = os.getenv("OPENROUTER_API_KEY")
 MODEL = os.getenv("OPENROUTER_MODEL", "openai/gpt-4o-mini")
 MAX_CONCURRENCY = int(os.getenv("LLM_MAX_CONCURRENCY", "2"))
 llm_client = LLMClient(API_KEY, MODEL, max_concurrent_requests=MAX_CONCURRENCY) if (LLMClient and API_KEY) else None
+
+logger = logging.getLogger(__name__)
 
 # Пытаемся использовать клиент OpenRouter; если его нет — fallback на локальный анализатор
 try:
@@ -111,7 +114,7 @@ def process_single_text_file(args, silent: bool = False, log_file: str | None = 
                     except Exception:
                         pass
                 else:
-                    print(msg)
+                    logger.error(msg)
             return None  # прерываем обработку текущего файла
 
     time_taken = time.time() - start_time
@@ -132,7 +135,7 @@ def process_single_text_file(args, silent: bool = False, log_file: str | None = 
             with open(log_file, 'a', encoding='utf-8') as f:
                 f.write(message + '\n')
     else:
-        print(message)
+        logger.info(message)
 
     return {
         "file_path": file_path,


### PR DESCRIPTION
## Summary
- replace stray print statements with logger usage
- drop unused NLTK and cmake dependencies
- switch image metadata extraction to regex-based tokenization

## Testing
- `python -m py_compile file_utils.py image_data_processing.py data_processing_common.py text_data_processing.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_68a780351ca8833083e488bb24a345b5