### PR TITLE
Add env example and ignore local env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Environment variables for docrouter
+# Copy this file to .env and fill in the values
+
+# API key for OpenRouter
+OPENROUTER_API_KEY=your_openrouter_api_key
+
+# Optional: model to use via OpenRouter
+OPENROUTER_MODEL=openai/gpt-4o-mini
+
+# Optional: maximum number of concurrent LLM requests
+LLM_MAX_CONCURRENCY=2

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ venv/
 # Ignore example output files
 organized_folder/
 operation_log.txt
+
+# Local environment variables
+.env


### PR DESCRIPTION
## Summary
- Add `.env.example` template for OpenRouter settings
- Ignore local `.env` file in Git

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7832595c08330b5021b87fd6aee2e