### PR TITLE
Use OpenRouter client for metadata and handle failures

### DIFF
--- a/main.py
+++ b/main.py
@@ -8,8 +8,7 @@ from typing import Dict, Any
 
 from PIL import Image
 import pytesseract
-import urllib.request
-import urllib.error
+from openrouter_client import fetch_metadata_from_llm
 
 from file_utils import collect_file_paths, read_file_data
 from data_processing_common import sanitize_filename
@@ -37,40 +36,6 @@ def extract_text_and_metadata(file_path: str) -> tuple[str, Dict[str, Any]]:
     return text, metadata
 
 
-def call_llm(text: str, metadata: Dict[str, Any], retries: int = 2) -> Dict[str, Any]:
-    """Call OpenRouter LLM to classify document and return structured JSON."""
-    api_key = os.getenv("OPENROUTER_API_KEY")
-    if not api_key:
-        raise RuntimeError("OPENROUTER_API_KEY not set")
-    url = "https://openrouter.ai/api/v1/chat/completions"
-    headers = {
-        "Authorization": f"Bearer {api_key}",
-        "Content-Type": "application/json",
-    }
-    prompt = (
-        "You are a document classifier. Extract fields as JSON with keys:"
-        " category, subcategory, date, issuer, person, document_type, amount, tags,"
-        " suggested_filename, note. Return only valid JSON."
-        f"\nText: {text}\nMetadata: {metadata}"
-    )
-    model = os.getenv("OPENROUTER_MODEL", "openai/gpt-3.5-turbo")
-    for attempt in range(retries):
-        try:
-            payload = json.dumps({
-                "model": model,
-                "messages": [{"role": "user", "content": prompt}],
-                "temperature": 0,
-            }).encode("utf-8")
-            req = urllib.request.Request(url, data=payload, headers=headers)
-            with urllib.request.urlopen(req, timeout=60) as resp:
-                data = json.loads(resp.read().decode("utf-8"))
-            content = data["choices"][0]["message"]["content"]
-            return json.loads(content)
-        except Exception as err:
-            last_err = err
-    raise last_err
-
-
 def build_storage_path(base_path: str, info: Dict[str, Any], original_path: str) -> str:
     """Build destination path based on LLM info."""
     category = info.get("category") or "Unsorted"
@@ -90,10 +55,18 @@ def build_storage_path(base_path: str, info: Dict[str, Any], original_path: str)
 def process_file(file_path: str, output_path: str, dry_run: bool, logger: logging.Logger) -> None:
     text, metadata = extract_text_and_metadata(file_path)
     try:
-        llm_info = call_llm(text, metadata)
+        llm_info = fetch_metadata_from_llm(text)
     except Exception as e:
         logger.error("LLM failed for %s: %s", file_path, e)
-        llm_info = {"category": "Unsorted", "subcategory": "", "issuer": "", "person": "", "suggested_filename": os.path.splitext(os.path.basename(file_path))[0]}
+        unsorted_dir = os.path.join(output_path, "Unsorted")
+        dest = os.path.join(unsorted_dir, os.path.basename(file_path))
+        if dry_run:
+            logger.info("Dry-run: would move %s -> %s", file_path, dest)
+            return
+        os.makedirs(unsorted_dir, exist_ok=True)
+        shutil.move(file_path, dest)
+        logger.info("Moved %s -> %s", file_path, dest)
+        return
     destination = build_storage_path(output_path, llm_info, file_path)
     if dry_run:
         logger.info("Dry-run: would move %s -> %s", file_path, destination)


### PR DESCRIPTION
## Summary
- Remove local OpenRouter call and use `fetch_metadata_from_llm`
- Send documents to `Unsorted` when LLM call fails and log action
- Drop unused `urllib` imports

## Testing
- `python -m py_compile main.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a783340000833084988e1da78ec86c