### PR TITLE
Centralize configuration loading and add examples

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+OPENROUTER_API_KEY=your_api_key_here
+OPENROUTER_MODEL=openrouter/llama3-8b
+LLM_MAX_CONCURRENCY=2

--- a/agent.md
+++ b/agent.md
@@ -76,6 +76,29 @@
 
 Модель и ключ OpenRouter указываются в .env.
 
+Пример `.env`:
+
+```
+OPENROUTER_API_KEY=your_api_key_here
+OPENROUTER_MODEL=openrouter/llama3-8b
+LLM_MAX_CONCURRENCY=2
+```
+
+Пример `config.yml`:
+
+```
+categories:
+  - Receipts
+  - Insurance
+  - School
+people:
+  - Alice
+  - Bob
+vendors:
+  - Amazon
+  - IKEA
+```
+
 Производительность и лимиты
 
 Документы обрабатываются по очереди, чтобы не упираться в лимиты API.

--- a/config.yml
+++ b/config.yml
@@ -1,3 +1,4 @@
+# Пример конфигурации. Пустые списки допустимы.
 categories:
   - Receipts
   - Insurance

--- a/config_loader.py
+++ b/config_loader.py
@@ -1,17 +1,41 @@
 import os
+from dataclasses import dataclass, field
+from typing import List
+
 from dotenv import load_dotenv
 import yaml
 
 
-def load_config(config_path: str = "config.yml"):
-    """Load application configuration from a YAML file."""
-    with open(config_path, "r", encoding="utf-8") as f:
-        return yaml.safe_load(f)
+@dataclass
+class AppConfig:
+    """Основная конфигурация приложения."""
+
+    categories: List[str] = field(default_factory=list)
+    people: List[str] = field(default_factory=list)
+    vendors: List[str] = field(default_factory=list)
+
+
+def load_config(config_path: str = "config.yml") -> AppConfig:
+    """Загрузить конфигурацию приложения из YAML-файла."""
+    data = {}
+    if os.path.exists(config_path):
+        with open(config_path, "r", encoding="utf-8") as f:
+            data = yaml.safe_load(f) or {}
+    return AppConfig(
+        categories=data.get("categories", []),
+        people=data.get("people", []),
+        vendors=data.get("vendors", []),
+    )
 
 
 def load_openrouter_settings():
-    """Load OpenRouter API key and model from environment variables."""
+    """Загрузить настройки OpenRouter из переменных окружения."""
     load_dotenv()
     api_key = os.getenv("OPENROUTER_API_KEY")
-    model = os.getenv("OPENROUTER_MODEL")
-    return {"api_key": api_key, "model": model}
+    model = os.getenv("OPENROUTER_MODEL", "openrouter/llama3-8b")
+    max_concurrency = int(os.getenv("LLM_MAX_CONCURRENCY", "2"))
+    return {
+        "api_key": api_key,
+        "model": model,
+        "max_concurrency": max_concurrency,
+    }

--- a/main.py
+++ b/main.py
@@ -6,6 +6,8 @@ import shutil
 import time
 from typing import Dict, Any
 
+from config_loader import load_config, load_openrouter_settings
+
 from PIL import Image
 import pytesseract
 import urllib.request
@@ -37,9 +39,13 @@ def extract_text_and_metadata(file_path: str) -> tuple[str, Dict[str, Any]]:
     return text, metadata
 
 
+OPENROUTER = load_openrouter_settings()
+CONFIG = load_config()
+
+
 def call_llm(text: str, metadata: Dict[str, Any], retries: int = 2) -> Dict[str, Any]:
     """Call OpenRouter LLM to classify document and return structured JSON."""
-    api_key = os.getenv("OPENROUTER_API_KEY")
+    api_key = OPENROUTER.get("api_key")
     if not api_key:
         raise RuntimeError("OPENROUTER_API_KEY not set")
     url = "https://openrouter.ai/api/v1/chat/completions"
@@ -53,7 +59,7 @@ def call_llm(text: str, metadata: Dict[str, Any], retries: int = 2) -> Dict[str,
         " suggested_filename, note. Return only valid JSON."
         f"\nText: {text}\nMetadata: {metadata}"
     )
-    model = os.getenv("OPENROUTER_MODEL", "openai/gpt-3.5-turbo")
+    model = OPENROUTER.get("model")
     for attempt in range(retries):
         try:
             payload = json.dumps({

--- a/openrouter_client.py
+++ b/openrouter_client.py
@@ -1,7 +1,8 @@
-import os
 import time
 import json
 import requests
+
+from config_loader import load_openrouter_settings
 
 OPENROUTER_API_URL = "https://openrouter.ai/api/v1/chat/completions"
 EXPECTED_FIELDS = [
@@ -22,8 +23,9 @@ def fetch_metadata_from_llm(text, max_retries=3):
 
     Retries the request if the model returns invalid JSON.
     """
-    api_key = os.getenv("OPENROUTER_API_KEY")
-    model = os.getenv("OPENROUTER_MODEL", "openrouter/llama3-8b")
+    settings = load_openrouter_settings()
+    api_key = settings.get("api_key")
+    model = settings.get("model")
     if not api_key:
         raise RuntimeError("OPENROUTER_API_KEY is not set")
 

--- a/text_data_processing.py
+++ b/text_data_processing.py
@@ -3,6 +3,7 @@ import time
 import logging
 
 from data_processing_common import sanitize_filename, extract_file_metadata
+from config_loader import load_config, load_openrouter_settings
 
 # Логгер
 logger = logging.getLogger(__name__)
@@ -19,10 +20,16 @@ try:
 except Exception:
     LLMClient = None
 
-API_KEY = os.getenv("OPENROUTER_API_KEY")
-MODEL = os.getenv("OPENROUTER_MODEL", "openai/gpt-4o-mini")
-MAX_CONCURRENCY = int(os.getenv("LLM_MAX_CONCURRENCY", "2"))
-llm_client = LLMClient(API_KEY, MODEL, max_concurrent_requests=MAX_CONCURRENCY) if (LLMClient and API_KEY) else None
+CONFIG = load_config()
+OR_SETTINGS = load_openrouter_settings()
+API_KEY = OR_SETTINGS.get("api_key")
+MODEL = OR_SETTINGS.get("model")
+MAX_CONCURRENCY = OR_SETTINGS.get("max_concurrency", 2)
+llm_client = (
+    LLMClient(API_KEY, MODEL, max_concurrent_requests=MAX_CONCURRENCY)
+    if (LLMClient and API_KEY)
+    else None
+)
 
 # Источник AI-метаданных: OpenRouter или локальный анализатор
 try:


### PR DESCRIPTION
## Summary
- add `AppConfig` dataclass with default lists for categories, people and vendors
- centralize OpenRouter settings (model and concurrency) and use them across modules
- update docs and provide sample `.env` and `config.yml`

## Testing
- `python -m pytest`
- `python -m py_compile config_loader.py openrouter_client.py text_data_processing.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_68a783330e108330851af346aff96140