### PR TITLE
Replace print statements with logging in file utilities

### DIFF
--- a/file_utils.py
+++ b/file_utils.py
@@ -1,8 +1,12 @@
 import os
+import logging
 import fitz  # PyMuPDF
 import docx
 import pandas as pd  # для Excel и CSV
 from pptx import Presentation  # для PPT/PPTX
+
+
+logger = logging.getLogger(__name__)
 
 
 def read_text_file(file_path: str) -> str | None:
@@ -12,7 +16,7 @@ def read_text_file(file_path: str) -> str | None:
         with open(file_path, 'r', encoding='utf-8', errors='ignore') as file:
             return file.read(max_chars)
     except Exception as e:
-        print(f"Error reading text file {file_path}: {e}")
+        logger.error("Error reading text file %s: %s", file_path, e)
         return None
 
 
@@ -22,7 +26,7 @@ def read_docx_file(file_path: str) -> str | None:
         doc = docx.Document(file_path)
         return '\n'.join(p.text for p in doc.paragraphs)
     except Exception as e:
-        print(f"Error reading DOCX file {file_path}: {e}")
+        logger.error("Error reading DOCX file %s: %s", file_path, e)
         return None
 
 
@@ -37,7 +41,7 @@ def read_pdf_file(file_path: str) -> str | None:
             pages.append(page.get_text())
         return '\n'.join(pages)
     except Exception as e:
-        print(f"Error reading PDF file {file_path}: {e}")
+        logger.error("Error reading PDF file %s: %s", file_path, e)
         return None
 
 
@@ -50,7 +54,7 @@ def read_spreadsheet_file(file_path: str) -> str | None:
             df = pd.read_excel(file_path)
         return df.to_string()
     except Exception as e:
-        print(f"Error reading spreadsheet file {file_path}: {e}")
+        logger.error("Error reading spreadsheet file %s: %s", file_path, e)
         return None
 
 
@@ -65,7 +69,7 @@ def read_ppt_file(file_path: str) -> str | None:
                     chunks.append(shape.text)
         return '\n'.join(chunks)
     except Exception as e:
-        print(f"Error reading PowerPoint file {file_path}: {e}")
+        logger.error("Error reading PowerPoint file %s: %s", file_path, e)
         return None
 
 


### PR DESCRIPTION
## Summary
- Use logging instead of print statements in file reading helpers to maintain consistent logging
- Verify main entrypoint already runs pipeline without interactive prompts
- Confirm requirements contain no unused dependencies like `nltk` or `rich`

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a7860699d48330a5c0023087d3eeb8