### PR TITLE
Очистка утилит: удалены функции дат и лишние метаданные

### DIFF
--- a/data_processing_common.py
+++ b/data_processing_common.py
@@ -2,7 +2,6 @@ import os
 import re
 import json
 import logging
-import datetime  # Import datetime for date operations
 
 def sanitize_filename(name, max_length=50, max_words=5):
     """Sanitize the filename by removing unwanted words and characters."""
@@ -33,17 +32,6 @@ def sanitize_filename(name, max_length=50, max_words=5):
     # Limit length
     return limited_name[:max_length] if limited_name else 'untitled'
 
-
-def extract_file_metadata(file_path):
-    """Извлечь основные метаданные файла."""
-    stats = os.stat(file_path)
-    return {
-        "size": stats.st_size,
-        "created": datetime.datetime.fromtimestamp(stats.st_ctime).isoformat(),
-        "modified": datetime.datetime.fromtimestamp(stats.st_mtime).isoformat(),
-    }
-
-
 def build_storage_path(info, original_path, base_path="Archive", dry_run=False, logger=None):
     """Сформировать путь для сохранения файла по данным LLM."""
     category = info.get("category") or "Unsorted"
@@ -67,10 +55,12 @@ def build_storage_path(info, original_path, base_path="Archive", dry_run=False, 
     return dest_file
 
 
-def write_metadata(dest_file, info, file_meta, dry_run=False, logger=None):
+def write_metadata(dest_file, info, file_meta=None, dry_run=False, logger=None):
     """Записать метаданные в JSON рядом с файлом."""
     meta_path = dest_file + ".json"
-    data = {"llm": info, "file": file_meta}
+    data = {"llm": info}
+    if file_meta is not None:
+        data["file"] = file_meta
     if dry_run:
         if logger:
             logger.info("Dry-run: метаданные %s не записываются", meta_path)

--- a/image_data_processing.py
+++ b/image_data_processing.py
@@ -4,14 +4,14 @@ import logging
 from PIL import Image
 import pytesseract
 
-from data_processing_common import sanitize_filename, extract_file_metadata
+from data_processing_common import sanitize_filename
 from error_handling import handle_model_error
 
 logger = logging.getLogger(__name__)
 
 
 def process_single_image(image_path: str, silent: bool = False, log_file: str | None = None):
-    """Обработать одно изображение: OCR → базовые метаданные → простое имя и папка."""
+    """Обработать одно изображение: OCR → простое имя и папка."""
     start_time = time.time()
 
     # 1) OCR
@@ -22,10 +22,7 @@ def process_single_image(image_path: str, silent: bool = False, log_file: str | 
         handle_model_error(image_path, f"OCR error: {e}", response="", log_file=log_file)
         return None
 
-    # 2) Метаданные файла
-    metadata = extract_file_metadata(image_path)
-
-    # 3) Генерация имени/папки (без LLM, минимально)
+    # 2) Генерация имени/папки (без LLM, минимально)
     try:
         foldername, filename, description = generate_image_metadata(image_path)
     except Exception as e:
@@ -33,7 +30,7 @@ def process_single_image(image_path: str, silent: bool = False, log_file: str | 
         handle_model_error(image_path, str(e), response, log_file=log_file)
         return None
 
-    # 4) Лог
+    # 3) Лог
     time_taken = time.time() - start_time
     summary = f"{image_path} -> {foldername}/{filename} ({time_taken:.2f}s)"
     if log_file:
@@ -48,7 +45,6 @@ def process_single_image(image_path: str, silent: bool = False, log_file: str | 
         "filename": filename,
         "description": description,
         "text": extracted_text,
-        "metadata": metadata,
     }
 
 

--- a/text_data_processing.py
+++ b/text_data_processing.py
@@ -2,7 +2,7 @@ import os
 import time
 import logging
 
-from data_processing_common import sanitize_filename, extract_file_metadata
+from data_processing_common import sanitize_filename
 
 # Логгер
 logger = logging.getLogger(__name__)
@@ -29,7 +29,6 @@ def process_single_text_file(args, silent: bool = False, log_file: str | None = 
     file_path, text = args
     start_time = time.time()
 
-    file_meta = extract_file_metadata(file_path)
     ai_meta = safe_fetch_ai_metadata(text)
 
     try:
@@ -66,7 +65,7 @@ def process_single_text_file(args, silent: bool = False, log_file: str | None = 
         "foldername": foldername,
         "filename": filename,
         "description": description,
-        "metadata": {"file": file_meta, "ai": ai_meta},
+        "metadata": ai_meta,
     }
 
 


### PR DESCRIPTION
## Summary
- удалить функцию `extract_file_metadata` и упростить `write_metadata`
- убрать использование удалённой функции из обработчиков текста и изображений
- убрать возврат лишних метаданных из обработчиков

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a786334f4c833098bdfe7e9bf9252e