### PR TITLE
Add document saver utility and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/src/saver.py
+++ b/src/saver.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+from typing import Dict
+
+
+def store_document(path: Path, metadata: Dict) -> Path:
+    """Сохранить документ и его метаданные в архив.
+
+    На основе полей ``категория``, ``подкатегория`` и ``человек``/``организация``
+    формируется итоговый путь ``Архив/<Категория>/<Подкатегория>/<Человек или Организация>``.
+    Файл копируется в полученный каталог, а JSON с метаданными сохраняется рядом
+    с расширением ``.json``.
+
+    Parameters
+    ----------
+    path:
+        Путь к исходному файлу.
+    metadata:
+        Словарь с метаданными документа.
+
+    Returns
+    -------
+    Path
+        Путь к сохранённому файлу в архиве.
+    """
+
+    category = metadata.get("категория", "Unknown")
+    subcategory = metadata.get("подкатегория", "Unknown")
+    person_or_org = (
+        metadata.get("человек")
+        or metadata.get("организация")
+        or metadata.get("человек/организация")
+        or "Unknown"
+    )
+
+    dest_dir = Path("Архив") / category / subcategory / person_or_org
+    dest_dir.mkdir(parents=True, exist_ok=True)
+
+    dest_path = dest_dir / path.name
+    shutil.copy2(path, dest_path)
+
+    meta_path = dest_path.with_suffix(dest_path.suffix + ".json")
+    with meta_path.open("w", encoding="utf-8") as f:
+        json.dump(metadata, f, ensure_ascii=False, indent=2)
+
+    return dest_path.resolve()

--- a/tests/test_saver.py
+++ b/tests/test_saver.py
@@ -1,0 +1,49 @@
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+from saver import store_document
+
+
+def test_store_document_uses_person(tmp_path, monkeypatch):
+    source = tmp_path / "input.txt"
+    source.write_text("data", encoding="utf-8")
+    metadata = {
+        "категория": "Платежи",
+        "подкатегория": "Коммунальные",
+        "человек": "Иван",
+    }
+
+    monkeypatch.chdir(tmp_path)
+    dest = store_document(source, metadata)
+
+    expected = tmp_path / "Архив" / "Платежи" / "Коммунальные" / "Иван" / "input.txt"
+    assert dest == expected and dest.exists()
+    assert dest.read_text(encoding="utf-8") == "data"
+
+    meta_path = dest.with_suffix(dest.suffix + ".json")
+    saved_metadata = json.loads(meta_path.read_text(encoding="utf-8"))
+    assert saved_metadata == metadata
+
+
+def test_store_document_uses_organization(tmp_path, monkeypatch):
+    source = tmp_path / "doc.pdf"
+    source.write_text("content", encoding="utf-8")
+    metadata = {
+        "категория": "Отчёты",
+        "подкатегория": "Годовой",
+        "организация": "ООО Ромашка",
+    }
+
+    monkeypatch.chdir(tmp_path)
+    dest = store_document(source, metadata)
+
+    expected = tmp_path / "Архив" / "Отчёты" / "Годовой" / "ООО Ромашка" / "doc.pdf"
+    assert dest == expected and dest.exists()
+
+    meta_path = dest.with_suffix(dest.suffix + ".json")
+    saved_metadata = json.loads(meta_path.read_text(encoding="utf-8"))
+    assert saved_metadata == metadata


### PR DESCRIPTION
## Summary
- implement `store_document` to archive files and save metadata JSON
- add tests verifying proper path construction for persons and organizations
- ignore Python cache files

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a78a1e7d2083309d0f7701a0165bbb