### PR TITLE
Добавлен сканер документов и тесты

### DIFF
--- a/src/scanner.py
+++ b/src/scanner.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _is_hidden_or_temp(part: str) -> bool:
+    """Check whether a path component is hidden or temporary."""
+    return (
+        part.startswith('.')
+        or part.startswith('~')
+        or part.endswith('~')
+        or part.startswith('#')
+        or part.endswith('#')
+    )
+
+
+def list_documents(input_dir: Path) -> list[Path]:
+    """Recursively list document files in ``input_dir``.
+
+    Hidden and temporary files or directories are skipped.
+    """
+    result: list[Path] = []
+    for path in input_dir.rglob('*'):
+        if not path.is_file():
+            continue
+        parts = path.relative_to(input_dir).parts
+        if any(_is_hidden_or_temp(part) for part in parts):
+            continue
+        result.append(path)
+    return sorted(result)

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -1,0 +1,31 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from scanner import list_documents
+
+
+def test_list_documents_filters_hidden_and_temp(tmp_path: Path) -> None:
+    (tmp_path / "visible.txt").touch()
+    (tmp_path / ".hidden.txt").touch()
+    (tmp_path / "tempfile~").touch()
+    (tmp_path / "~temp.txt").touch()
+    (tmp_path / "#temp#").touch()
+
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    (sub / "inner.txt").touch()
+    (sub / ".hidden_inner.txt").touch()
+    (sub / "inner_temp~").touch()
+
+    hidden_dir = tmp_path / ".hidden_dir"
+    hidden_dir.mkdir()
+    (hidden_dir / "inside_hidden.txt").touch()
+
+    temp_dir = sub / "~tempdir"
+    temp_dir.mkdir()
+    (temp_dir / "inside_temp.txt").touch()
+
+    expected = sorted([tmp_path / "visible.txt", sub / "inner.txt"])
+    assert list_documents(tmp_path) == expected


### PR DESCRIPTION
## Summary
- Реализован модуль `scanner` для рекурсивного получения списка документов с фильтрацией скрытых и временных файлов
- Добавлены юнит-тесты на корректность работы функции

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a78a0bf39c833080ea98204343164a