### PR TITLE
Добавлен модуль извлечения текста и тесты

### DIFF
--- a/src/extractor.py
+++ b/src/extractor.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+from PIL import Image
+import pytesseract
+
+
+def extract_text(path: Path) -> str:
+    """Извлечь текст из изображения или PDF-файла."""
+    suffix = path.suffix.lower()
+    if suffix in {".png", ".jpg", ".jpeg", ".tif", ".tiff", ".bmp", ".gif"}:
+        image = Image.open(path)
+        return pytesseract.image_to_string(image)
+    elif suffix == ".pdf":
+        try:
+            from pdfminer.high_level import extract_text as pdf_extract_text
+        except Exception as exc:
+            raise RuntimeError("Для обработки PDF требуется пакет pdfminer.six") from exc
+        return pdf_extract_text(str(path))
+    else:
+        raise ValueError(f"Неподдерживаемый тип файла: {suffix}")

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+import sys
+import types
+
+from PIL import Image, ImageDraw
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+from extractor import extract_text
+
+
+def test_extract_text_image(monkeypatch, tmp_path):
+    image_path = tmp_path / "sample.png"
+    img = Image.new("RGB", (100, 40), color=(255, 255, 255))
+    draw = ImageDraw.Draw(img)
+    draw.text((10, 10), "hi", fill=(0, 0, 0))
+    img.save(image_path)
+
+    monkeypatch.setattr("pytesseract.image_to_string", lambda img: "hi")
+
+    assert extract_text(image_path) == "hi"
+
+
+def test_extract_text_pdf(monkeypatch, tmp_path):
+    pdf_path = tmp_path / "sample.pdf"
+    pdf_path.write_bytes(b"%PDF-1.4")
+
+    fake_pdfminer = types.ModuleType("pdfminer")
+    high_level = types.ModuleType("pdfminer.high_level")
+    high_level.extract_text = lambda path: "pdf text"
+    sys.modules["pdfminer"] = fake_pdfminer
+    sys.modules["pdfminer.high_level"] = high_level
+
+    assert extract_text(pdf_path) == "pdf text"


### PR DESCRIPTION
## Summary
- добавить функцию `extract_text` для получения текста из изображений и PDF
- покрыть функцию тестами с фиктивными файлами

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a78a1298c48330880ae9d946b6c99d