### PR TITLE
feat: add OpenRouter client

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,0 +1,1 @@
+model: openai/gpt-4.1-mini

--- a/src/llm_client.py
+++ b/src/llm_client.py
@@ -1,0 +1,49 @@
+import os
+from pathlib import Path
+import requests
+import yaml
+
+OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions"
+
+
+def _load_config() -> dict:
+    """Загружает конфигурацию из YAML-файла.
+
+    Путь к файлу можно переопределить переменной окружения
+    ``DOCROUTER_CONFIG``.
+    """
+    config_path = os.environ.get("DOCROUTER_CONFIG", "config.yml")
+    with open(Path(config_path), encoding="utf-8") as f:
+        return yaml.safe_load(f) or {}
+
+
+def analyze_text(text: str) -> dict:
+    """Отправляет текст в OpenRouter и возвращает распарсенный JSON.
+
+    Модель берётся из конфигурационного файла. Возможные ошибки сети и
+    невалидный JSON оборачиваются в ``RuntimeError``.
+    """
+    config = _load_config()
+    model = config.get("model", "")
+    api_key = os.environ.get("OPENROUTER_API_KEY", "")
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+    payload = {
+        "model": model,
+        "messages": [{"role": "user", "content": text}],
+    }
+
+    try:
+        response = requests.post(
+            OPENROUTER_URL, headers=headers, json=payload, timeout=30
+        )
+        response.raise_for_status()
+    except requests.RequestException as exc:  # ошибки сети
+        raise RuntimeError("OpenRouter request failed") from exc
+
+    try:
+        return response.json()
+    except ValueError as exc:  # невалидный JSON
+        raise RuntimeError("Invalid JSON received from OpenRouter") from exc

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -1,0 +1,62 @@
+import pytest
+import requests
+from src.llm_client import analyze_text
+
+
+def _prepare_config(monkeypatch, tmp_path, content="model: test-model\n"):
+    cfg = tmp_path / "config.yml"
+    cfg.write_text(content, encoding="utf-8")
+    monkeypatch.setenv("DOCROUTER_CONFIG", str(cfg))
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test")
+
+
+def test_analyze_text_success(monkeypatch, tmp_path):
+    _prepare_config(monkeypatch, tmp_path)
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        assert json["model"] == "test-model"
+        assert json["messages"][0]["content"] == "hello"
+
+        class Resp:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {"result": "ok"}
+
+        return Resp()
+
+    monkeypatch.setattr(requests, "post", fake_post)
+
+    assert analyze_text("hello") == {"result": "ok"}
+
+
+def test_analyze_text_network_error(monkeypatch, tmp_path):
+    _prepare_config(monkeypatch, tmp_path)
+
+    def fake_post(*args, **kwargs):
+        raise requests.RequestException("boom")
+
+    monkeypatch.setattr(requests, "post", fake_post)
+
+    with pytest.raises(RuntimeError):
+        analyze_text("data")
+
+
+def test_analyze_text_invalid_json(monkeypatch, tmp_path):
+    _prepare_config(monkeypatch, tmp_path)
+
+    class Resp:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            raise ValueError("not json")
+
+    def fake_post(*args, **kwargs):
+        return Resp()
+
+    monkeypatch.setattr(requests, "post", fake_post)
+
+    with pytest.raises(RuntimeError):
+        analyze_text("data")


### PR DESCRIPTION
## Summary
- add OpenRouter client with configurable model
- handle network and JSON errors
- test client behavior via API stubs

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a78a155700833095e4b825403dec6e