### PR TITLE
feat: add error handling module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/src/error_handler.py
+++ b/src/error_handler.py
@@ -1,0 +1,66 @@
+import logging
+import os
+from pathlib import Path
+import shutil
+from typing import Optional
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+
+def _str_to_bool(value: str) -> bool:
+    return value.lower() in {"1", "true", "yes", "y"}
+
+
+def is_dry_run() -> bool:
+    """Determine whether the application runs in dry-run mode.
+
+    Priority is given to the ``DRY_RUN`` environment variable. If it is not
+    set, the configuration file is consulted. The path to the configuration
+    file can be overridden via the ``CONFIG_PATH`` environment variable.
+    """
+    env_val = os.getenv("DRY_RUN")
+    if env_val is not None:
+        return _str_to_bool(env_val)
+
+    config_path_env = os.getenv("CONFIG_PATH")
+    if config_path_env:
+        config_path = Path(config_path_env)
+    else:
+        config_path = Path(__file__).resolve().parent.parent / "config.yml"
+
+    if config_path.exists():
+        try:
+            with config_path.open("r", encoding="utf-8") as fh:
+                data = yaml.safe_load(fh) or {}
+            dry_value = data.get("dry_run")
+            if isinstance(dry_value, bool):
+                return dry_value
+            if isinstance(dry_value, str):
+                return _str_to_bool(dry_value)
+        except Exception as exc:  # pragma: no cover - logging of config issues
+            logger.warning("Failed to read config file %s: %s", config_path, exc)
+    return False
+
+
+def handle_error(path: Path, error: Exception) -> None:
+    """Handle processing errors.
+
+    The file ``path`` will be moved into an ``Unsorted`` subdirectory next to
+    its original location. In ``dry-run`` mode, only logging is performed.
+    """
+    logger.error("Error processing %s: %s", path, error)
+    destination_dir = path.parent / "Unsorted"
+    destination = destination_dir / path.name
+
+    if is_dry_run():
+        logger.info("Dry-run: would move %s to %s", path, destination)
+        return
+
+    try:
+        destination_dir.mkdir(parents=True, exist_ok=True)
+        shutil.move(str(path), str(destination))
+        logger.info("Moved %s to %s", path, destination)
+    except Exception as exc:  # pragma: no cover - secondary errors are rare
+        logger.error("Failed to move %s to %s: %s", path, destination, exc)

--- a/tests/test_error_handler.py
+++ b/tests/test_error_handler.py
@@ -1,0 +1,41 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+import error_handler
+
+
+def test_handle_error_moves_file(tmp_path, caplog, monkeypatch):
+    monkeypatch.delenv("DRY_RUN", raising=False)
+    test_file = tmp_path / "doc.txt"
+    test_file.write_text("content")
+    err = ValueError("boom")
+    with caplog.at_level("INFO"):
+        error_handler.handle_error(test_file, err)
+    dest = tmp_path / "Unsorted" / "doc.txt"
+    assert dest.exists()
+    assert not test_file.exists()
+    assert "Moved" in caplog.text
+
+
+def test_handle_error_dry_run(tmp_path, caplog, monkeypatch):
+    monkeypatch.setenv("DRY_RUN", "true")
+    test_file = tmp_path / "doc.txt"
+    test_file.write_text("content")
+    err = ValueError("boom")
+    with caplog.at_level("INFO"):
+        error_handler.handle_error(test_file, err)
+    dest = tmp_path / "Unsorted" / "doc.txt"
+    assert not dest.exists()
+    assert test_file.exists()
+    assert "Dry-run" in caplog.text
+
+
+def test_is_dry_run_from_config(tmp_path, monkeypatch):
+    monkeypatch.delenv("DRY_RUN", raising=False)
+    cfg = tmp_path / "config.yml"
+    cfg.write_text("dry_run: true\n")
+    monkeypatch.setenv("CONFIG_PATH", str(cfg))
+    assert error_handler.is_dry_run() is True


### PR DESCRIPTION
## Summary
- add error handler with optional dry-run mode
- move failed files to `Unsorted` and log
- cover error handler with unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a78a298f408330a19405010ffd4f02