### PR TITLE
feat: add main pipeline and tests

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+from pathlib import Path
+
+from src import error_handler, extractor, llm_client, saver, scanner
+
+logger = logging.getLogger(__name__)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Process documents in a folder")
+    parser.add_argument("input_dir", type=Path, help="Path to input directory")
+    parser.add_argument("--dry-run", action="store_true", help="Do not save results")
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+        help="Logging level",
+    )
+    return parser.parse_args(argv)
+
+
+def process_documents(input_dir: Path, dry_run: bool) -> tuple[int, int, int]:
+    documents = scanner.list_documents(input_dir)
+    total = len(documents)
+    successes = 0
+    failures = 0
+
+    for path in documents:
+        logger.info("Processing %s", path)
+        try:
+            text = extractor.extract_text(path)
+            metadata = llm_client.analyze_text(text)
+            if dry_run:
+                logger.info("Dry-run: would save %s", path)
+            else:
+                saver.store_document(path, metadata)
+            successes += 1
+        except Exception as exc:  # pragma: no cover - exercised via tests
+            error_handler.handle_error(path, exc)
+            failures += 1
+
+    return total, successes, failures
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    logging.basicConfig(level=getattr(logging, args.log_level.upper()))
+
+    if args.dry_run:
+        os.environ["DRY_RUN"] = "1"
+    else:
+        os.environ.pop("DRY_RUN", None)
+
+    total, successes, failures = process_documents(args.input_dir, args.dry_run)
+    logger.info(
+        "Processed %d files: %d succeeded, %d failed", total, successes, failures
+    )
+    print(f"Processed {total} files: {successes} succeeded, {failures} failed")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,76 @@
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+# Stub external dependencies to avoid heavy installations
+yaml_stub = types.SimpleNamespace(safe_load=lambda *a, **k: {})
+sys.modules.setdefault("yaml", yaml_stub)
+
+requests_stub = types.SimpleNamespace()
+sys.modules.setdefault("requests", requests_stub)
+
+PIL_module = types.ModuleType("PIL")
+image_module = types.ModuleType("Image")
+image_module.open = lambda path: path
+PIL_module.Image = image_module
+sys.modules.setdefault("PIL", PIL_module)
+sys.modules.setdefault("PIL.Image", image_module)
+
+pytesseract_stub = types.SimpleNamespace(image_to_string=lambda img: "")
+sys.modules.setdefault("pytesseract", pytesseract_stub)
+
+# Ensure repository root is on path for importing main
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import main
+
+
+def test_main_success(monkeypatch, tmp_path, caplog):
+    monkeypatch.delenv("DRY_RUN", raising=False)
+    docs = [tmp_path / "a.txt", tmp_path / "b.txt"]
+
+    monkeypatch.setattr(main.scanner, "list_documents", lambda p: docs)
+
+    def fake_extract(path):
+        return f"text-{path.name}"
+
+    monkeypatch.setattr(main.extractor, "extract_text", fake_extract)
+    monkeypatch.setattr(main.llm_client, "analyze_text", lambda text: {"summary": text})
+    saved = []
+    monkeypatch.setattr(main.saver, "store_document", lambda path, meta: saved.append((path, meta)))
+
+    caplog.set_level("INFO")
+    main.main([str(tmp_path)])
+
+    assert saved == [
+        (docs[0], {"summary": "text-a.txt"}),
+        (docs[1], {"summary": "text-b.txt"}),
+    ]
+    assert "Processed 2 files" in caplog.text
+
+
+def test_main_dry_run_and_error(monkeypatch, tmp_path):
+    monkeypatch.delenv("DRY_RUN", raising=False)
+    docs = [tmp_path / "a.txt", tmp_path / "b.txt"]
+    monkeypatch.setattr(main.scanner, "list_documents", lambda p: docs)
+
+    def fake_extract(path):
+        if path.name == "b.txt":
+            raise RuntimeError("boom")
+        return "ok"
+
+    monkeypatch.setattr(main.extractor, "extract_text", fake_extract)
+    monkeypatch.setattr(main.llm_client, "analyze_text", lambda text: {"summary": text})
+    saved = []
+    monkeypatch.setattr(main.saver, "store_document", lambda path, meta: saved.append((path, meta)))
+    handled = []
+    monkeypatch.setattr(
+        main.error_handler, "handle_error", lambda path, err: handled.append((path, str(err)))
+    )
+
+    main.main([str(tmp_path), "--dry-run"])
+
+    assert saved == []  # dry-run skips saving
+    assert handled == [(docs[1], "boom")]


### PR DESCRIPTION
## Summary
- add main entry point with argument parsing, logging, and dry-run handling
- integrate scanner, extractor, LLM analysis, saving and error handling
- cover the pipeline with integration tests using stubbed dependencies

## Testing
- `pip install pyyaml pillow pytesseract requests` *(fails: Could not connect to proxy)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `pytest tests/test_main.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a78b8cebf88330bbe39938c5fe7a32