### PR TITLE
Добавлен модуль построения пути с нормализацией метаданных

### DIFF
--- a/src/path_builder.py
+++ b/src/path_builder.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Dict, Iterable, Optional
+
+import yaml
+
+
+def _load_config() -> Dict:
+    """Load configuration from YAML file.
+
+    The path to the configuration file can be overridden via the
+    ``DOCROUTER_CONFIG`` environment variable.
+    """
+    config_path = os.getenv("DOCROUTER_CONFIG", "config.yml")
+    with open(Path(config_path), encoding="utf-8") as fh:
+        return yaml.safe_load(fh) or {}
+
+
+def _normalize(value: Optional[str], options: Iterable[str]) -> Optional[str]:
+    """Return canonical form of ``value`` if it exists in ``options``.
+
+    Matching is case-insensitive. If ``value`` is ``None`` or not found,
+    ``None`` is returned.
+    """
+    if not value:
+        return None
+    mapping = {opt.casefold(): opt for opt in options}
+    return mapping.get(value.strip().casefold())
+
+
+def build_target_path(metadata: Dict) -> Path:
+    """Construct destination path based on ``metadata``.
+
+    The result has the form ``Архив/<Категория>/<Подкатегория>/<Человек или Организация>``.
+    If any of the required fields is missing or unknown, ``Unsorted`` is
+    returned instead.
+    """
+    config = _load_config()
+    categories = config.get("categories", [])
+    subcategories = config.get("subcategories", [])
+    persons = config.get("persons", [])
+    organizations = config.get("organizations", [])
+
+    category = _normalize(metadata.get("категория"), categories)
+    subcategory = _normalize(metadata.get("подкатегория"), subcategories)
+
+    person = _normalize(metadata.get("человек"), persons)
+    organization = _normalize(metadata.get("организация"), organizations)
+    combined = persons + organizations
+    human_or_org = metadata.get("человек/организация")
+    human_or_org = _normalize(human_or_org, combined) if human_or_org else None
+    person_or_org = human_or_org or person or organization
+
+    if not all([category, subcategory, person_or_org]):
+        return Path("Unsorted")
+
+    return Path("Архив") / category / subcategory / person_or_org

--- a/tests/test_path_builder.py
+++ b/tests/test_path_builder.py
@@ -1,0 +1,66 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+from path_builder import build_target_path
+
+
+@pytest.fixture
+def config_file(tmp_path, monkeypatch):
+    cfg = tmp_path / "config.yml"
+    cfg.write_text(
+        """
+        categories:
+          - Платежи
+          - Отчёты
+        subcategories:
+          - Коммунальные
+          - Годовой
+        persons:
+          - Иван
+        organizations:
+          - ООО Ромашка
+        """,
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DOCROUTER_CONFIG", str(cfg))
+    return cfg
+
+
+def test_build_target_path_normalizes_values(config_file):
+    metadata = {
+        "категория": "платежи",
+        "подкатегория": "коммунальные",
+        "человек/организация": "иван",
+    }
+    result = build_target_path(metadata)
+    expected = Path("Архив") / "Платежи" / "Коммунальные" / "Иван"
+    assert result == expected
+
+
+def test_build_target_path_unknown_category_returns_unsorted(config_file):
+    metadata = {
+        "категория": "неизвестная",
+        "подкатегория": "коммунальные",
+        "человек": "иван",
+    }
+    assert build_target_path(metadata) == Path("Unsorted")
+
+
+def test_build_target_path_missing_field_returns_unsorted(config_file):
+    metadata = {
+        "категория": "платежи",
+        "человек": "иван",
+    }
+    assert build_target_path(metadata) == Path("Unsorted")
+
+
+def test_build_target_path_unknown_person_returns_unsorted(config_file):
+    metadata = {
+        "категория": "платежи",
+        "подкатегория": "коммунальные",
+        "человек": "петр",
+    }
+    assert build_target_path(metadata) == Path("Unsorted")


### PR DESCRIPTION
## Summary
- Реализован `path_builder.build_target_path` с загрузкой конфигурации и нормализацией значений
- Добавлены тесты для проверки построения пути и обработки неизвестных значений

## Testing
- `pytest -q` *(ошибка: No module named 'yaml', 'PIL', 'requests')*
- `pip install pyyaml pillow requests` *(ошибка: Could not find a version that satisfies the requirement pyyaml)*

------
https://chatgpt.com/codex/tasks/task_e_68a78b8b7e8883308ca713435f9662b3