### PR TITLE
Добавлен централизованный логгер с ротацией

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,1 +1,8 @@
 model: openai/gpt-4.1-mini
+
+logging:
+  level: INFO
+  file: docrouter.log
+  max_bytes: 1048576
+  backup_count: 3
+  format: "%(asctime)s - %(name)s - %(levelname)s - %(message)s"

--- a/src/error_handler.py
+++ b/src/error_handler.py
@@ -1,12 +1,12 @@
-import logging
 import os
 from pathlib import Path
 import shutil
-from typing import Optional
 
 import yaml
 
-logger = logging.getLogger(__name__)
+from logger import get_logger
+
+logger = get_logger(__name__)
 
 
 def _str_to_bool(value: str) -> bool:

--- a/src/logger.py
+++ b/src/logger.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import logging
+from logging.handlers import RotatingFileHandler
+import os
+from pathlib import Path
+from functools import lru_cache
+
+import yaml
+
+
+DEFAULTS = {
+    "level": "INFO",
+    "file": "docrouter.log",
+    "max_bytes": 1024 * 1024,
+    "backup_count": 3,
+    "format": "%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+}
+
+
+@lru_cache()
+def _load_config() -> dict:
+    """Загрузить конфигурацию из YAML."""
+    config_path = os.environ.get("DOCROUTER_CONFIG", "config.yml")
+    try:
+        with open(Path(config_path), encoding="utf-8") as fh:
+            return yaml.safe_load(fh) or {}
+    except FileNotFoundError:
+        return {}
+
+
+@lru_cache()
+def _configure_root() -> int:
+    """Настроить корневой логгер и вернуть выбранный уровень."""
+    cfg = _load_config().get("logging", {})
+    level_name = str(cfg.get("level", DEFAULTS["level"])).upper()
+    level = getattr(logging, level_name, logging.INFO)
+
+    log_file = Path(cfg.get("file", DEFAULTS["file"]))
+    log_file.parent.mkdir(parents=True, exist_ok=True)
+    max_bytes = int(cfg.get("max_bytes", DEFAULTS["max_bytes"]))
+    backup_count = int(cfg.get("backup_count", DEFAULTS["backup_count"]))
+    fmt = cfg.get("format", DEFAULTS["format"])
+
+    handler = RotatingFileHandler(
+        log_file, maxBytes=max_bytes, backupCount=backup_count
+    )
+    handler.setFormatter(logging.Formatter(fmt))
+
+    root = logging.getLogger()
+    root.setLevel(level)
+    if not any(isinstance(h, RotatingFileHandler) for h in root.handlers):
+        root.addHandler(handler)
+    return level
+
+
+def get_logger(name: str) -> logging.Logger:
+    """Получить настроенный логгер по имени."""
+    level = _configure_root()
+    logger = logging.getLogger(name)
+    logger.setLevel(level)
+    return logger

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,0 +1,41 @@
+import sys
+import importlib
+import logging
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+
+def test_get_logger_rotates(tmp_path, monkeypatch):
+    cfg = tmp_path / "config.yml"
+    log_file = tmp_path / "app.log"
+    cfg.write_text(
+        f"""
+logging:
+  level: INFO
+  file: "{log_file}"
+  max_bytes: 100
+  backup_count: 1
+  format: "%(levelname)s:%(message)s"
+"""
+    )
+    monkeypatch.setenv("DOCROUTER_CONFIG", str(cfg))
+
+    root = logging.getLogger()
+    root.handlers.clear()
+
+    import logger
+
+    importlib.reload(logger)
+
+    log = logger.get_logger("test")
+    for _ in range(20):
+        log.info("x" * 10)
+
+    assert log_file.exists()
+    assert log_file.with_suffix(".1").exists()
+    assert "INFO:xxxxxxxxxx" in log_file.read_text()
+
+    root.handlers.clear()


### PR DESCRIPTION
## Summary
- добавить модуль `get_logger` с настройкой формата, уровня и ротации по конфигу
- заменить прямое использование `logging` в `error_handler`
- добавить тест ротации логов и параметры логирования в `config.yml`

## Testing
- `pytest` *(не прошёл: ModuleNotFoundError: No module named 'PIL' и 'requests')*
- `pip install Pillow requests` *(не удалось: Tunnel connection failed: 403 Forbidden)*
- `pip install PyYAML` *(не удалось: Tunnel connection failed: 403 Forbidden)*


------
https://chatgpt.com/codex/tasks/task_e_68a78b8c2f0c833092689baa3d8ce33b