### PR TITLE
feat: add metadata validation

### DIFF
--- a/src/llm_client.py
+++ b/src/llm_client.py
@@ -3,6 +3,8 @@ from pathlib import Path
 import requests
 import yaml
 
+from .metadata_schema import validate_metadata
+
 OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions"
 
 
@@ -44,6 +46,8 @@ def analyze_text(text: str) -> dict:
         raise RuntimeError("OpenRouter request failed") from exc
 
     try:
-        return response.json()
+        data = response.json()
     except ValueError as exc:  # невалидный JSON
         raise RuntimeError("Invalid JSON received from OpenRouter") from exc
+
+    return validate_metadata(data)

--- a/src/metadata_schema.py
+++ b/src/metadata_schema.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, ValidationError
+
+
+class Metadata(BaseModel):
+    """Схема метаданных, возвращаемых LLM."""
+
+    result: str
+
+
+def validate_metadata(data: dict) -> dict:
+    """Проверяет словарь с метаданными и возвращает нормализованный результат.
+
+    :param data: словарь, полученный от LLM
+    :raises ValueError: если данные не соответствуют схеме
+    :return: нормализованные метаданные
+    """
+    try:
+        metadata = Metadata(**data)
+    except ValidationError as exc:  # noqa: F841
+        raise ValueError("invalid metadata") from exc
+    return metadata.dict()

--- a/tests/test_metadata_schema.py
+++ b/tests/test_metadata_schema.py
@@ -1,0 +1,13 @@
+import pytest
+
+from src.metadata_schema import validate_metadata
+
+
+def test_validate_metadata_ok():
+    data = {"result": "ok"}
+    assert validate_metadata(data) == data
+
+
+def test_validate_metadata_invalid():
+    with pytest.raises(ValueError):
+        validate_metadata({})


### PR DESCRIPTION
## Summary
- add `Metadata` Pydantic model and validation helper
- validate metadata in `llm_client.analyze_text`
- add tests for metadata validation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*


------
https://chatgpt.com/codex/tasks/task_e_68a78b8d90348330b12d901e56628728