### PR TITLE
Добавлен модуль file_utils и тесты для чтения файлов

### DIFF
--- a/src/file_utils/__init__.py
+++ b/src/file_utils/__init__.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable, Dict
+
+import csv
+
+try:
+    import fitz  # PyMuPDF
+except ImportError:  # pragma: no cover - dependency missing
+    fitz = None
+
+try:
+    from docx import Document
+except ImportError:  # pragma: no cover - dependency missing
+    Document = None
+
+
+def extract_text_txt(path: Path) -> str:
+    """Извлечение текста из .txt файла."""
+    return path.read_text(encoding="utf-8")
+
+
+def extract_text_md(path: Path) -> str:
+    """Извлечение текста из .md файла."""
+    return path.read_text(encoding="utf-8")
+
+
+def extract_text_pdf(path: Path) -> str:
+    """Извлечение текста из PDF с помощью PyMuPDF."""
+    if fitz is None:
+        raise RuntimeError("PyMuPDF не установлен")
+    text_parts = []
+    with fitz.open(path) as doc:
+        for page in doc:
+            text_parts.append(page.get_text())
+    return "\n".join(text_parts)
+
+
+def extract_text_docx(path: Path) -> str:
+    """Извлечение текста из DOCX."""
+    if Document is None:
+        raise RuntimeError("python-docx не установлен")
+    doc = Document(path)
+    return "\n".join(p.text for p in doc.paragraphs)
+
+
+def extract_text_csv(path: Path) -> str:
+    """Извлечение текста из CSV."""
+    lines = []
+    with path.open(newline="", encoding="utf-8") as f:
+        reader = csv.reader(f)
+        for row in reader:
+            lines.append(",".join(row))
+    return "\n".join(lines)
+
+
+_PARSERS: Dict[str, Callable[[Path], str]] = {
+    ".txt": extract_text_txt,
+    ".md": extract_text_md,
+    ".pdf": extract_text_pdf,
+    ".docx": extract_text_docx,
+    ".csv": extract_text_csv,
+}
+
+
+def extract_text(path: Path) -> str:
+    """Определяет парсер по расширению и извлекает текст."""
+    ext = path.suffix.lower()
+    if ext not in _PARSERS:
+        raise ValueError(f"Неизвестное расширение файла: {ext}")
+    return _PARSERS[ext](path)
+
+
+__all__ = [
+    "extract_text",
+    "extract_text_txt",
+    "extract_text_md",
+    "extract_text_pdf",
+    "extract_text_docx",
+    "extract_text_csv",
+]

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -1,0 +1,74 @@
+import sys
+from pathlib import Path
+import csv
+import importlib.util
+from tempfile import TemporaryDirectory
+import unittest
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from file_utils import extract_text
+
+
+def has_module(name: str) -> bool:
+    return importlib.util.find_spec(name) is not None
+
+
+def _create_file(base: Path, ext: str, text: str) -> Path:
+    path = base / f"file{ext}"
+    if ext in {".txt", ".md"}:
+        path.write_text(text, encoding="utf-8")
+    elif ext == ".csv":
+        with path.open("w", newline="", encoding="utf-8") as f:
+            writer = csv.writer(f)
+            writer.writerow(text.split(","))
+    elif ext == ".pdf":
+        import fitz
+
+        doc = fitz.open()
+        page = doc.new_page()
+        page.insert_text((72, 72), text)
+        doc.save(path)
+        doc.close()
+    elif ext == ".docx":
+        from docx import Document
+
+        doc = Document()
+        doc.add_paragraph(text)
+        doc.save(path)
+    else:
+        raise ValueError("unsupported ext")
+    return path
+
+
+class TestExtractText(unittest.TestCase):
+    def test_txt(self):
+        with TemporaryDirectory() as tmp:
+            path = _create_file(Path(tmp), ".txt", "hello txt")
+            self.assertEqual(extract_text(path).strip(), "hello txt")
+
+    def test_md(self):
+        with TemporaryDirectory() as tmp:
+            path = _create_file(Path(tmp), ".md", "hello md")
+            self.assertEqual(extract_text(path).strip(), "hello md")
+
+    def test_csv(self):
+        with TemporaryDirectory() as tmp:
+            path = _create_file(Path(tmp), ".csv", "a,b")
+            self.assertEqual(extract_text(path).strip(), "a,b")
+
+    @unittest.skipUnless(has_module("fitz"), "PyMuPDF not installed")
+    def test_pdf(self):
+        with TemporaryDirectory() as tmp:
+            path = _create_file(Path(tmp), ".pdf", "hello pdf")
+            self.assertEqual(extract_text(path).strip(), "hello pdf")
+
+    @unittest.skipUnless(has_module("docx"), "python-docx not installed")
+    def test_docx(self):
+        with TemporaryDirectory() as tmp:
+            path = _create_file(Path(tmp), ".docx", "hello docx")
+            self.assertEqual(extract_text(path).strip(), "hello docx")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Реализован модуль `file_utils` с функциями извлечения текста для разных форматов и общим диспетчером `extract_text`
- Добавлены модульные тесты на чтение файлов различных типов

## Testing
- `python3 -m unittest discover -s tests -v`


------
https://chatgpt.com/codex/tasks/task_e_68a78f1c766083308676afee827bc478