### PR TITLE
Добавить сортировку файлов по метаданным

### DIFF
--- a/src/file_sorter.py
+++ b/src/file_sorter.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+from typing import Any, Dict
+
+
+def place_file(src_path: str | Path, metadata: Dict[str, Any], dest_root: str | Path, dry_run: bool = False) -> Path:
+    """Перемещает файл в структуру папок на основе метаданных.
+
+    Создаёт вложенные папки (категория/подкатегория/issuer),
+    переименовывает файл вида ``DATE__NAME.ext`` и сохраняет рядом JSON
+    с теми же метаданными.
+
+    При ``dry_run=True`` только выводит предполагаемые действия.
+
+    Возвращает путь, по которому файл будет или был размещён.
+    """
+
+    src = Path(src_path)
+    ext = src.suffix
+    name = metadata.get("suggested_name") or src.stem
+    date = metadata.get("date", "unknown-date")
+
+    new_name = f"{date}__{name}{ext}"
+
+    dest_dir = Path(dest_root)
+    for key in ("category", "subcategory", "issuer"):
+        value = metadata.get(key)
+        if value:
+            dest_dir /= value
+
+    dest_file = dest_dir / new_name
+    json_file = dest_file.with_suffix(dest_file.suffix + ".json")
+
+    if dry_run:
+        print(f"Would move {src} -> {dest_file}")
+        print(f"Would write metadata JSON to {json_file}")
+        return dest_file
+
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    shutil.move(str(src), dest_file)
+
+    with open(json_file, "w", encoding="utf-8") as f:
+        json.dump(metadata, f, ensure_ascii=False, indent=2)
+
+    return dest_file

--- a/tests/test_file_sorter.py
+++ b/tests/test_file_sorter.py
@@ -1,0 +1,44 @@
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+from file_sorter import place_file
+
+
+def sample_metadata():
+    return {
+        "category": "Финансы",
+        "subcategory": "Банки",
+        "issuer": "Sparkasse",
+        "date": "2023-10-12",
+        "suggested_name": "Kreditvertrag",
+    }
+
+
+def test_place_file_path_and_name(tmp_path, capsys):
+    src = tmp_path / "input.pdf"
+    src.write_text("data")
+
+    dest_root = tmp_path / "Archive"
+    dest = place_file(src, sample_metadata(), dest_root, dry_run=True)
+
+    expected = dest_root / "Финансы" / "Банки" / "Sparkasse" / "2023-10-12__Kreditvertrag.pdf"
+    assert dest == expected
+
+
+def test_place_file_moves_and_creates_json(tmp_path):
+    src = tmp_path / "document.pdf"
+    src.write_text("content")
+
+    dest_root = tmp_path / "Archive"
+    dest = place_file(src, sample_metadata(), dest_root, dry_run=False)
+
+    json_path = dest.with_suffix(dest.suffix + ".json")
+    assert dest.exists()
+    assert json_path.exists()
+    with open(json_path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    assert data["issuer"] == "Sparkasse"


### PR DESCRIPTION
## Summary
- реализована функция `place_file` для раскладывания файлов по метаданным и создания JSON
- добавлены тесты на формирование пути и имени файла

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a78f25435c8330b43a9834c266c846