### PR TITLE
Добавлен OCR для изображений и тест

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,1 @@
+# Package initializer for src

--- a/src/file_utils/__init__.py
+++ b/src/file_utils/__init__.py
@@ -1,0 +1,27 @@
+"""Utility functions for extracting text from files."""
+
+from pathlib import Path
+from typing import Union
+
+from .image_ocr import extract_text_image
+
+
+def extract_text(file_path: Union[str, Path], language: str = "eng") -> str:
+    """Extract text from a supported file.
+
+    Currently supports plain text files and images (.jpg, .jpeg).
+
+    :param file_path: Path to the file.
+    :param language: Language for OCR when processing images.
+    :return: Extracted text.
+    :raises ValueError: If the file format is not supported.
+    """
+    path = Path(file_path)
+    suffix = path.suffix.lower()
+
+    if suffix in {".jpg", ".jpeg"}:
+        return extract_text_image(path, language=language)
+    elif suffix in {".txt", ".md"}:
+        return path.read_text(encoding="utf-8")
+    else:
+        raise ValueError(f"Unsupported file format: {suffix}")

--- a/src/file_utils/image_ocr.py
+++ b/src/file_utils/image_ocr.py
@@ -1,0 +1,23 @@
+"""OCR utilities for image files."""
+
+from pathlib import Path
+from typing import Union
+
+try:
+    from PIL import Image
+    import pytesseract
+except ModuleNotFoundError as exc:  # pragma: no cover - handled at runtime
+    raise ModuleNotFoundError(
+        "pytesseract and Pillow are required for OCR functionality"
+    ) from exc
+
+
+def extract_text_image(image_path: Union[str, Path], language: str = "eng") -> str:
+    """Extract text from an image using Tesseract OCR.
+
+    :param image_path: Path to the image file.
+    :param language: Language for OCR (default 'eng').
+    :return: Extracted text as a string.
+    """
+    img = Image.open(Path(image_path))
+    return pytesseract.image_to_string(img, lang=language)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+import sys
+from pathlib import Path
+
+# Ensure the src directory is on the Python path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'src'))

--- a/tests/test_image_ocr.py
+++ b/tests/test_image_ocr.py
@@ -1,0 +1,14 @@
+from PIL import Image, ImageDraw, ImageFont
+
+from file_utils import extract_text
+
+
+def test_extract_text_from_image(tmp_path):
+    image = Image.new('RGB', (100, 50), color='white')
+    draw = ImageDraw.Draw(image)
+    draw.text((10, 10), 'OCR', fill='black', font=ImageFont.load_default())
+    image_path = tmp_path / 'sample.jpg'
+    image.save(image_path)
+
+    text = extract_text(image_path)
+    assert 'OCR' in text


### PR DESCRIPTION
## Summary
- Добавлена поддержка OCR для JPEG-изображений через Tesseract
- Функция `extract_text` обновлена: удалена обработка PNG, тест генерирует JPEG на лету

## Testing
- `pip install pillow pytesseract pytest` *(ошибка: Could not find a version that satisfies the requirement pillow)*
- `pytest -q` *(ошибка: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_68a78f1dbfb0833092ad1b101f444ad4