### PR TITLE
Обновление .gitignore для Python и директорий приложения

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,18 @@
+# Python
 __pycache__/
-*.pyc
-.env
+*.py[cod]
 .venv/
-.vscode
+.env
+dist/
+build/
+
+# Application output
+Archive/
+Unsorted/
+logs/
 uploads/
 sorted/
+
+# Editor and tools
+.vscode
 .pytest_cache/


### PR DESCRIPTION
## Summary
- Добавлены стандартные правила игнорирования Python и служебных файлов
- Исключены каталоги результатов работы приложения

## Testing
- `pytest` *(неудачно: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68a791243e088330bd1b88afac290a02