### PR TITLE
Добавлена обработка ошибок при маршрутизации документов

### DIFF
--- a/src/docrouter.py
+++ b/src/docrouter.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from file_utils import extract_text
+from generate_metadata import generate_metadata
+from file_sorter import place_file
+
+from error_handling import handle_error
+
+
+def process_directory(input_dir: str | Path, dest_root: str | Path, dry_run: bool = False) -> None:
+    """Process all files from *input_dir* and place them under *dest_root*.
+
+    Each file is passed through the pipeline: ``extract_text`` →
+    ``generate_metadata`` → ``place_file``.  Any exception during processing is
+    delegated to :func:`handle_error`.
+    """
+    input_path = Path(input_dir)
+    for path in input_path.iterdir():
+        if not path.is_file():
+            continue
+        try:
+            text = extract_text(path)
+            metadata = generate_metadata(text)
+            place_file(path, metadata, dest_root, dry_run=dry_run)
+        except Exception as exc:  # pragma: no cover - depending on runtime errors
+            handle_error(path, exc)

--- a/src/error_handling.py
+++ b/src/error_handling.py
@@ -1,0 +1,36 @@
+import json
+import logging
+import shutil
+from pathlib import Path
+import traceback
+
+logger = logging.getLogger(__name__)
+
+
+def handle_error(file_path: str | Path, exception: Exception) -> None:
+    """Log *exception*, move *file_path* to ``Unsorted`` and write JSON with details.
+
+    The JSON is stored under ``errors/<filename>.json`` where ``<filename>`` is the
+    original file name (including extension).
+    """
+    src = Path(file_path)
+    logger.error("Ошибка при обработке %s: %s", src, exception)
+
+    # Перемещаем файл в Unsorted/
+    unsorted_dir = Path("Unsorted")
+    unsorted_dir.mkdir(exist_ok=True)
+    dest = unsorted_dir / src.name
+    if src.exists():
+        shutil.move(str(src), dest)
+
+    # Сохраняем сведения об ошибке
+    errors_dir = Path("errors")
+    errors_dir.mkdir(exist_ok=True)
+    error_info = {
+        "file": src.name,
+        "error": str(exception),
+        "traceback": traceback.format_exc(),
+    }
+    error_file = errors_dir / f"{src.name}.json"
+    with open(error_file, "w", encoding="utf-8") as f:
+        json.dump(error_info, f, ensure_ascii=False, indent=2)

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -1,0 +1,35 @@
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from docrouter import process_directory
+
+
+def test_parse_error_moves_file_and_creates_json(tmp_path):
+    input_dir = tmp_path / "input"
+    input_dir.mkdir()
+    bad_file = input_dir / "bad.xyz"
+    bad_file.write_text("data", encoding="utf-8")
+
+    dest_root = tmp_path / "Archive"
+
+    # Выполняем обработку, чтобы Unsorted и errors создавались в tmp_path
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        process_directory(input_dir, dest_root, dry_run=True)
+    finally:
+        os.chdir(cwd)
+
+    moved = tmp_path / "Unsorted" / "bad.xyz"
+    assert moved.exists()
+
+    error_json = tmp_path / "errors" / "bad.xyz.json"
+    assert error_json.exists()
+    data = json.loads(error_json.read_text(encoding="utf-8"))
+    assert "Unsupported/unknown" in data["error"]


### PR DESCRIPTION
## Summary
- реализован модуль `error_handling.handle_error` с логированием, переносом файлов в `Unsorted/` и сохранением JSON с описанием ошибки
- добавлен `docrouter.process_directory`, который оборачивает обработку каждого файла в `try/except` и использует `handle_error`
- написан тест, проверяющий перенос проблемных файлов и создание JSON

## Testing
- `pytest tests/test_error_handling.py -q`
- `pytest -q` *(ошибка: ModuleNotFoundError: No module named 'PIL'; No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_68a7915947b08330aa13ea7c6545eae0