### PR TITLE
feat: add output directory option

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,5 +15,6 @@ cp env.example .env
 - `OPENROUTER_API_KEY` — ключ для доступа к OpenRouter;
 - `DB_URL` — строка подключения к базе данных;
 - `LOG_LEVEL` — уровень логирования (например, `INFO`);
-- `TESSERACT_LANG` — язык для OCR Tesseract (например, `eng`).
+- `TESSERACT_LANG` — язык для OCR Tesseract (например, `eng`);
+- `OUTPUT_DIR` — папка, куда будут сохраняться обработанные документы (например, `Archive`).
 

--- a/env.example
+++ b/env.example
@@ -1,4 +1,16 @@
+## Параметры приложения
+
+# Ключ для доступа к OpenRouter
 OPENROUTER_API_KEY=
+
+# Строка подключения к базе данных
 DB_URL=
+
+# Уровень логирования
 LOG_LEVEL=INFO
+
+# Язык для OCR Tesseract
 TESSERACT_LANG=eng
+
+# Папка для сохранения обработанных документов
+OUTPUT_DIR=Archive


### PR DESCRIPTION
## Summary
- document OUTPUT_DIR env variable
- explain output directory configuration

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL')*


------
https://chatgpt.com/codex/tasks/task_e_68a79410dfb88330a8556e543843e299