### PR TITLE
Handle nested directories in docrouter

### DIFF
--- a/src/docrouter.py
+++ b/src/docrouter.py
@@ -17,12 +17,14 @@ def process_directory(input_dir: str | Path, dest_root: str | Path, dry_run: boo
     delegated to :func:`handle_error`.
     """
     input_path = Path(input_dir)
-    for path in input_path.iterdir():
+    for path in input_path.rglob("*"):
         if not path.is_file():
             continue
         try:
             text = extract_text(path)
             metadata = metadata_generation.generate_metadata(text)
-            place_file(path, metadata, dest_root, dry_run=dry_run)
+            rel_dir = path.parent.relative_to(input_path)
+            dest_base = Path(dest_root) / rel_dir
+            place_file(path, metadata, dest_base, dry_run=dry_run)
         except Exception as exc:  # pragma: no cover - depending on runtime errors
             handle_error(path, exc)

--- a/tests/test_docrouter_recursive.py
+++ b/tests/test_docrouter_recursive.py
@@ -1,0 +1,26 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from docrouter import process_directory
+import metadata_generation
+
+
+def test_process_directory_preserves_subdirs(tmp_path, monkeypatch):
+    input_dir = tmp_path / "input" / "sub1" / "sub2"
+    input_dir.mkdir(parents=True)
+    file_path = input_dir / "data.txt"
+    file_path.write_text("hello", encoding="utf-8")
+
+    def fake_generate(text):
+        return {"date": "2024-01-01"}
+
+    monkeypatch.setattr(metadata_generation, "generate_metadata", fake_generate)
+
+    dest_root = tmp_path / "Archive"
+    process_directory(tmp_path / "input", dest_root)
+
+    expected = dest_root / "sub1" / "sub2" / "2024-01-01__data.txt"
+    assert expected.exists()
+    assert not file_path.exists()


### PR DESCRIPTION
## Summary
- Recurse through subdirectories in `process_directory` and preserve relative paths when moving files
- Add regression test ensuring nested input folders keep their structure

## Testing
- `pytest -q` *(fails: No module named 'requests')*


------
https://chatgpt.com/codex/tasks/task_e_68a823ffc2dc8330a0beb25da9c2a1c3