### PR TITLE
Перенос настройки логирования в точку входа

### DIFF
--- a/src/file_sorter.py
+++ b/src/file_sorter.py
@@ -6,11 +6,7 @@ import shutil
 from pathlib import Path
 from typing import Any, Dict
 
-from config import LOG_LEVEL
-from logging_config import setup_logging
-
 logger = logging.getLogger(__name__)
-setup_logging(LOG_LEVEL, None)
 
 
 def place_file(src_path: str | Path, metadata: Dict[str, Any], dest_root: str | Path, dry_run: bool = False) -> Path:


### PR DESCRIPTION
## Summary
- Удалена настройка логирования на уровне модуля `file_sorter`
- Сервер конфигурирует логирование через `setup_logging` и использует параметры конфигурации в нижнем регистре

## Testing
- `pytest tests/test_file_sorter.py tests/test_file_utils.py -q`
- `pytest -q` *(failed: No module named 'requests'; No module named 'PIL'; No module named 'fastapi')*
- `pip install requests fastapi pillow` *(failed: Could not find a version that satisfies the requirement requests)*

------
https://chatgpt.com/codex/tasks/task_e_68a8240342d4833082b796ba5bcaa5b7