### PR TITLE
Fallback to RegexAnalyzer when OpenRouter unavailable

### DIFF
--- a/src/metadata_generation.py
+++ b/src/metadata_generation.py
@@ -101,14 +101,22 @@ class RegexAnalyzer(MetadataAnalyzer):
 def generate_metadata(text: str, analyzer: Optional[MetadataAnalyzer] = None) -> Dict[str, Any]:
     """Generate metadata for *text* using the provided *analyzer*.
 
-    If *analyzer* is ``None``, :class:`OpenRouterAnalyzer` is used which requires
-    an ``OPENROUTER_API_KEY`` environment variable.  The returned dictionary
-    always contains the following fields: ``category``, ``subcategory``,
-    ``issuer``, ``person``, ``doc_type``, ``date``, ``amount``, ``tags``,
-    ``suggested_filename``, ``description``.
+    If *analyzer* is ``None`` the function tries to create an
+    :class:`OpenRouterAnalyzer`.  When an API key is missing or the
+    OpenRouter analyzer cannot be instantiated for any reason, the
+    lightweight :class:`RegexAnalyzer` is used as a fallback.
+
+    The returned dictionary always contains the following fields:
+    ``category``, ``subcategory``, ``issuer``, ``person``, ``doc_type``,
+    ``date``, ``amount``, ``tags``, ``suggested_filename``,
+    ``description``.
     """
 
-    analyzer = analyzer or OpenRouterAnalyzer()
+    if analyzer is None:
+        try:
+            analyzer = OpenRouterAnalyzer()
+        except Exception:
+            analyzer = RegexAnalyzer()
     metadata = analyzer.analyze(text)
     defaults = {
         "category": None,

--- a/tests/test_metadata_generation.py
+++ b/tests/test_metadata_generation.py
@@ -1,0 +1,10 @@
+from metadata_generation import generate_metadata
+
+
+def test_generate_metadata_without_api_key(monkeypatch):
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    text = "Total 123.45 on 2023-05-17"
+    result = generate_metadata(text)
+    assert result["date"] == "2023-05-17"
+    assert result["amount"] == "123.45"
+    assert result["category"] is None


### PR DESCRIPTION
## Summary
- fall back to RegexAnalyzer if OpenRouter can't be initialized
- add test for metadata generation without OpenRouter API key

## Testing
- `pytest -q` *(fails: The starlette.testclient module requires the httpx package to be installed)*
- `pip install httpx` *(fails: Could not find a version that satisfies the requirement httpx)*
- `pytest tests/test_metadata_generation.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a823ec62208330a2947c3bfa35d017