### PR TITLE
feat: add file listing endpoint

### DIFF
--- a/src/web_app/server.py
+++ b/src/web_app/server.py
@@ -1,23 +1,21 @@
 from __future__ import annotations
 
+import logging
 import uuid
 from pathlib import Path
-from typing import Dict, Any
+from typing import Any, Dict
 
-from fastapi import FastAPI, UploadFile, File, HTTPException
+from fastapi import FastAPI, File, HTTPException, Request, UploadFile
 
 from config import load_config
-from logging_config import setup_logging
 from file_utils import extract_text
-import metadata_generation
 from file_sorter import place_file
+import metadata_generation
 
 app = FastAPI()
 
 # Load configuration and set up logging
 config = load_config()
-
-
 logging.basicConfig(level=getattr(logging, config.log_level.upper(), logging.INFO))
 
 
@@ -47,8 +45,14 @@ async def upload_file(file: UploadFile = File(...), dry_run: bool = False):
         raise HTTPException(status_code=500, detail=str(exc)) from exc
 
     status = "dry_run" if dry_run else "processed"
-    METADATA_STORE[file_id] = metadata
-    return {"id": file_id, "metadata": metadata, "path": str(dest_path), "status": status}
+    stored_metadata = {**metadata, "path": str(dest_path)}
+    METADATA_STORE[file_id] = stored_metadata
+    return {
+        "id": file_id,
+        "metadata": stored_metadata,
+        "path": str(dest_path),
+        "status": status,
+    }
 
 
 @app.get("/metadata/{file_id}")
@@ -58,3 +62,15 @@ async def get_metadata(file_id: str):
     if not data:
         raise HTTPException(status_code=404, detail="Metadata not found")
     return data
+
+
+@app.get("/files")
+async def list_files(request: Request):
+    """Return all files with optional metadata filtering."""
+    filters = dict(request.query_params)
+    items = []
+    for file_id, metadata in METADATA_STORE.items():
+        if all(str(metadata.get(k)) == v for k, v in filters.items()):
+            filename = Path(metadata.get("path", "")).name
+            items.append({"id": file_id, "filename": filename, "metadata": metadata})
+    return items

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -1,27 +1,44 @@
+import asyncio
 import os
 import sys
-from fastapi.testclient import TestClient
+from io import BytesIO
+
+from fastapi import UploadFile
+from starlette.requests import Request
 
 sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
 
-from web_app.server import app  # noqa: E402
+from web_app.server import METADATA_STORE, get_metadata, list_files, upload_file  # noqa: E402
 
 
 def test_upload_and_retrieve_metadata():
-    client = TestClient(app)
-    response = client.post(
-        "/upload",
-        files={"file": ("example.txt", b"content")},
-        params={"dry_run": True},
-    )
-    assert response.status_code == 200
-    data = response.json()
+    METADATA_STORE.clear()
+    file = UploadFile(filename="example.txt", file=BytesIO(b"content"))
+    data = asyncio.run(upload_file(file, dry_run=True))
     assert set(["id", "metadata", "path", "status"]).issubset(data.keys())
     file_id = data["id"]
     assert data["status"] == "dry_run"
     assert data["metadata"]["extracted_text"].strip() == "content"
+    assert data["metadata"]["path"] == data["path"]
 
-    response2 = client.get(f"/metadata/{file_id}")
-    assert response2.status_code == 200
-    data2 = response2.json()
+    data2 = asyncio.run(get_metadata(file_id))
     assert data2 == data["metadata"]
+
+
+def test_list_files_with_filter():
+    METADATA_STORE.clear()
+    file1 = UploadFile(filename="f1.txt", file=BytesIO(b"2023-10-12 amount 100"))
+    file2 = UploadFile(filename="f2.txt", file=BytesIO(b"2023-10-13 amount 200"))
+
+    data1 = asyncio.run(upload_file(file1, dry_run=True))
+    data2 = asyncio.run(upload_file(file2, dry_run=True))
+
+    request_all = Request({"type": "http", "query_string": b""})
+    items = asyncio.run(list_files(request_all))
+    ids = {item["id"] for item in items}
+    assert {data1["id"], data2["id"]} <= ids
+
+    request_filter = Request({"type": "http", "query_string": b"date=2023-10-12"})
+    filtered = asyncio.run(list_files(request_filter))
+    assert len(filtered) == 1
+    assert filtered[0]["id"] == data1["id"]


### PR DESCRIPTION
## Summary
- store final file path in metadata
- add /files endpoint with metadata filtering
- test file listing and filtering

## Testing
- `pytest tests/test_web_app.py -q`
- `pytest -q` *(fails: TesseractNotFoundError: tesseract is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68a825c86b7c83309114308d20dd2f9a