### PR TITLE
Add HTTP Basic auth to web endpoints

### DIFF
--- a/src/web_app/server.py
+++ b/src/web_app/server.py
@@ -5,7 +5,11 @@ import uuid
 from pathlib import Path
 from typing import Dict, Any
 
-from fastapi import FastAPI, UploadFile, File, HTTPException
+from fastapi import FastAPI, UploadFile, File, HTTPException, Depends
+from fastapi.responses import FileResponse
+from fastapi.security import HTTPBasic, HTTPBasicCredentials
+import os
+import secrets
 
 from config import load_config
 from file_utils import extract_text
@@ -14,11 +18,28 @@ from file_sorter import place_file
 
 app = FastAPI()
 
+security = HTTPBasic()
+
+
+def check_credentials(credentials: HTTPBasicCredentials = Depends(security)) -> str:
+    """Проверить учетные данные из HTTP Basic auth."""
+    user = os.getenv("DOCROUTER_USER", "")
+    password = os.getenv("DOCROUTER_PASS", "")
+    valid_user = secrets.compare_digest(credentials.username, user)
+    valid_pass = secrets.compare_digest(credentials.password, password)
+    if not (valid_user and valid_pass):
+        raise HTTPException(
+            status_code=401,
+            detail="Invalid credentials",
+            headers={"WWW-Authenticate": "Basic"},
+        )
+    return credentials.username
+
 # Load configuration
 config = load_config()
 logging.basicConfig(level=getattr(logging, config.LOG_LEVEL.upper(), logging.INFO))
 
-# In-memory store for metadata
+# In-memory store for metadata and file paths
 METADATA_STORE: Dict[str, Dict[str, Any]] = {}
 
 UPLOAD_DIR = Path("uploads")
@@ -26,7 +47,11 @@ UPLOAD_DIR.mkdir(exist_ok=True)
 
 
 @app.post("/upload")
-async def upload_file(file: UploadFile = File(...), dry_run: bool = False):
+async def upload_file(
+    file: UploadFile = File(...),
+    dry_run: bool = False,
+    _: str = Depends(check_credentials),
+):
     """Upload a file and process it."""
     file_id = str(uuid.uuid4())
     temp_path = UPLOAD_DIR / f"{file_id}_{file.filename}"
@@ -44,14 +69,37 @@ async def upload_file(file: UploadFile = File(...), dry_run: bool = False):
         raise HTTPException(status_code=500, detail=str(exc)) from exc
 
     status = "dry_run" if dry_run else "processed"
-    METADATA_STORE[file_id] = metadata
-    return {"id": file_id, "metadata": metadata, "path": str(dest_path), "status": status}
+    METADATA_STORE[file_id] = {"metadata": metadata, "path": str(dest_path)}
+    return {
+        "id": file_id,
+        "metadata": metadata,
+        "path": str(dest_path),
+        "status": status,
+    }
 
 
 @app.get("/metadata/{file_id}")
-async def get_metadata(file_id: str):
+async def get_metadata(file_id: str, _: str = Depends(check_credentials)):
     """Retrieve stored metadata by file ID."""
     data = METADATA_STORE.get(file_id)
     if not data:
         raise HTTPException(status_code=404, detail="Metadata not found")
-    return data
+    return data["metadata"]
+
+
+@app.get("/files")
+async def list_files(_: str = Depends(check_credentials)):
+    """List all stored files with their metadata."""
+    return [{"id": fid, "metadata": d["metadata"]} for fid, d in METADATA_STORE.items()]
+
+
+@app.get("/download/{file_id}")
+async def download_file(file_id: str, _: str = Depends(check_credentials)):
+    """Download processed file by ID."""
+    data = METADATA_STORE.get(file_id)
+    if not data:
+        raise HTTPException(status_code=404, detail="File not found")
+    path = Path(data.get("path", ""))
+    if not path.exists():
+        raise HTTPException(status_code=404, detail="File not found")
+    return FileResponse(path, filename=path.name)

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -1,27 +1,63 @@
 import os
 import sys
+import tempfile
 from fastapi.testclient import TestClient
 
-sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
+# Ensure the src directory is on the Python path
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'src'))
 
-from web_app.server import app  # noqa: E402
+# Set credentials and output directory before importing the app
+os.environ['DOCROUTER_USER'] = 'user'
+os.environ['DOCROUTER_PASS'] = 'pass'
+os.environ['OUTPUT_DIR'] = tempfile.mkdtemp()
+
+from web_app import server  # noqa: E402
 
 
-def test_upload_and_retrieve_metadata():
-    client = TestClient(app)
-    response = client.post(
-        "/upload",
-        files={"file": ("example.txt", b"content")},
-        params={"dry_run": True},
-    )
+def _mock_generate_metadata(text: str):
+    return {
+        'category': None,
+        'subcategory': None,
+        'issuer': None,
+        'person': None,
+        'doc_type': None,
+        'date': '2024-01-01',
+        'amount': None,
+        'tags': [],
+        'suggested_filename': None,
+        'description': None,
+    }
+
+
+def test_upload_retrieve_and_download(monkeypatch):
+    monkeypatch.setattr(server.metadata_generation, 'generate_metadata', _mock_generate_metadata)
+    server.METADATA_STORE.clear()
+    client = TestClient(server.app)
+
+    response = client.post('/upload', files={'file': ('example.txt', b'content')}, auth=('user', 'pass'))
     assert response.status_code == 200
     data = response.json()
-    assert set(["id", "metadata", "path", "status"]).issubset(data.keys())
-    file_id = data["id"]
-    assert data["status"] == "dry_run"
-    assert data["metadata"]["extracted_text"].strip() == "content"
+    file_id = data['id']
 
-    response2 = client.get(f"/metadata/{file_id}")
-    assert response2.status_code == 200
-    data2 = response2.json()
-    assert data2 == data["metadata"]
+    meta = client.get(f'/metadata/{file_id}', auth=('user', 'pass'))
+    assert meta.status_code == 200
+    assert meta.json() == data['metadata']
+
+    files_resp = client.get('/files', auth=('user', 'pass'))
+    assert files_resp.status_code == 200
+    assert any(f['id'] == file_id for f in files_resp.json())
+
+    download_resp = client.get(f'/download/{file_id}', auth=('user', 'pass'))
+    assert download_resp.status_code == 200
+    assert download_resp.content == b'content'
+
+
+def test_invalid_credentials():
+    client = TestClient(server.app)
+
+    resp = client.post('/upload', files={'file': ('example.txt', b'content')}, auth=('user', 'wrong'))
+    assert resp.status_code == 401
+
+    resp2 = client.get('/files', auth=('user', 'wrong'))
+    assert resp2.status_code == 401
+


### PR DESCRIPTION
## Summary
- add HTTP Basic auth using credentials from DOCROUTER_USER/DOCROUTER_PASS
- secure upload, metadata, files list and download endpoints
- test valid and invalid credentials for protected routes

## Testing
- `pytest tests/test_web_app.py::test_upload_retrieve_and_download -q` *(fails: ModuleNotFoundError: No module named 'httpx')*


------
https://chatgpt.com/codex/tasks/task_e_68a825738c34833088732403a7a3329e