### PR TITLE
Add file download route

### DIFF
--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -4,7 +4,9 @@ from fastapi.testclient import TestClient
 
 sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
 
-from web_app.server import app  # noqa: E402
+from web_app import server  # noqa: E402
+
+app = server.app
 
 
 def test_upload_and_retrieve_metadata():
@@ -25,3 +27,35 @@ def test_upload_and_retrieve_metadata():
     assert response2.status_code == 200
     data2 = response2.json()
     assert data2 == data["metadata"]
+
+
+def test_download_file(tmp_path):
+    server.METADATA_STORE.clear()
+    server.config.output_dir = str(tmp_path)
+    client = TestClient(app)
+    response = client.post(
+        "/upload",
+        files={"file": ("example.txt", b"content")},
+    )
+    file_id = response.json()["id"]
+    download = client.get(f"/download/{file_id}")
+    assert download.status_code == 200
+    assert download.content == b"content"
+
+
+def test_download_file_not_found(tmp_path):
+    server.METADATA_STORE.clear()
+    server.config.output_dir = str(tmp_path)
+    client = TestClient(app)
+    response = client.post(
+        "/upload",
+        files={"file": ("example.txt", b"content")},
+    )
+    file_id = response.json()["id"]
+    # remove file to trigger missing file 404
+    path = server.METADATA_STORE[file_id]["path"]
+    os.remove(path)
+    resp_missing = client.get(f"/download/{file_id}")
+    assert resp_missing.status_code == 404
+    resp_unknown = client.get("/download/unknown")
+    assert resp_unknown.status_code == 404


### PR DESCRIPTION
## Summary
- store file path in metadata store
- serve uploaded files via `/download/{file_id}`
- tests for download route and error handling

## Testing
- `pytest tests/test_web_app.py::test_download_file -q` *(fails: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68a825c702e4833086c7a292d58465c3