### PR TITLE
Add static upload form to web app

### DIFF
--- a/src/web_app/server.py
+++ b/src/web_app/server.py
@@ -3,8 +3,11 @@ from __future__ import annotations
 import uuid
 from pathlib import Path
 from typing import Dict, Any
+import logging
 
 from fastapi import FastAPI, UploadFile, File, HTTPException
+from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
 
 from config import load_config
 from logging_config import setup_logging
@@ -13,6 +16,14 @@ import metadata_generation
 from file_sorter import place_file
 
 app = FastAPI()
+
+app.mount("/static", StaticFiles(directory=Path(__file__).parent / "static"), name="static")
+
+
+@app.get("/")
+async def serve_index() -> FileResponse:
+    """Serve the upload form."""
+    return FileResponse(Path(__file__).parent / "static" / "index.html")
 
 # Load configuration and set up logging
 config = load_config()

--- a/src/web_app/static/index.html
+++ b/src/web_app/static/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Upload</title>
+</head>
+<body>
+    <form action="/upload" method="post" enctype="multipart/form-data">
+        <input type="file" name="file" />
+        <input type="submit" value="Upload" />
+    </form>
+</body>
+</html>

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -25,3 +25,10 @@ def test_upload_and_retrieve_metadata():
     assert response2.status_code == 200
     data2 = response2.json()
     assert data2 == data["metadata"]
+
+
+def test_root_returns_form():
+    client = TestClient(app)
+    response = client.get("/")
+    assert response.status_code == 200
+    assert '<form action="/upload" method="post" enctype="multipart/form-data">' in response.text


### PR DESCRIPTION
## Summary
- serve static upload form at root URL
- add test to ensure form is available

## Testing
- `pytest -q` *(fails: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68a825c9e6848330b1ee29aac8c35c19