### PR TITLE
feat: add main entry point for FastAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ pip install -r requirements.txt
 
 ## Запуск
 
-Запустите сервер FastAPI и откройте веб‑страницу для загрузки документов:
+Запустите сервер FastAPI через единый entry point и откройте веб‑страницу для загрузки документов:
 
 ```bash
-uvicorn src.web_app.server:app --reload
+python main.py --reload
 ```
 
 После запуска перейдите в браузере по адресу [http://localhost:8000](http://localhost:8000), чтобы загружать файлы и настраивать сервис через веб‑интерфейс.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 fastapi
 uvicorn
+httpx
 requests
 pydantic
 python-dotenv


### PR DESCRIPTION
## Summary
- add CLI entry point to launch FastAPI server
- document running the app via `python main.py`
- include httpx for test client support

## Testing
- `pip install httpx` *(fails: Tunnel connection failed: 403 Forbidden)*
- `pytest tests/test_web_app.py -q` *(fails: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68a82c82d5d08330ad1a3c474e826475