### PR TITLE
fix: use correct config attribute for DB URL

### DIFF
--- a/src/web_app/database.py
+++ b/src/web_app/database.py
@@ -8,7 +8,8 @@ from typing import Any, Dict, Optional, Union
 from config import load_config
 
 config = load_config()
-DB_PATH: Union[str, Path] = config.DB_URL or "metadata.db"
+# Используем нижний регистр, соответствующий определению в Config
+DB_PATH: Union[str, Path] = config.db_url or "metadata.db"
 if DB_PATH != ":memory:":
     DB_PATH = Path(DB_PATH)
 


### PR DESCRIPTION
## Summary
- use lower-case `db_url` attribute from `Config` when setting SQLite path

## Testing
- `pytest` *(failed: No module named 'httpx')*
- `pip install httpx` *(failed: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a82dcb71888330a8c9cb95ebb32331