### PR TITLE
feat: add logging and tests

### DIFF
--- a/src/docrouter.py
+++ b/src/docrouter.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 from pathlib import Path
+import logging
 
 from file_utils import extract_text
 import metadata_generation
 from file_sorter import place_file
 
 from error_handling import handle_error
+
+logger = logging.getLogger(__name__)
 
 
 def process_directory(input_dir: str | Path, dest_root: str | Path, dry_run: bool = False) -> None:
@@ -17,14 +20,18 @@ def process_directory(input_dir: str | Path, dest_root: str | Path, dry_run: boo
     delegated to :func:`handle_error`.
     """
     input_path = Path(input_dir)
+    logger.info("Processing directory %s", input_path)
     for path in input_path.rglob("*"):
         if not path.is_file():
             continue
+        logger.info("Processing file %s", path)
         try:
             text = extract_text(path)
             metadata = metadata_generation.generate_metadata(text)
             rel_dir = path.parent.relative_to(input_path)
             dest_base = Path(dest_root) / rel_dir
             place_file(path, metadata, dest_base, dry_run=dry_run)
+            logger.info("Finished processing %s", path)
         except Exception as exc:  # pragma: no cover - depending on runtime errors
             handle_error(path, exc)
+            logger.error("Failed to process %s: %s", path, exc)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,41 @@
+import logging
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from file_utils import extract_text
+from docrouter import process_directory
+import metadata_generation
+
+
+def test_extract_text_logs_error_for_unknown_extension(tmp_path, caplog):
+    file_path = tmp_path / "file.xyz"
+    file_path.write_text("data", encoding="utf-8")
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(ValueError):
+            extract_text(file_path)
+    assert "Unsupported/unknown file extension" in caplog.text
+
+
+def test_process_directory_logs(tmp_path, monkeypatch, caplog):
+    input_dir = tmp_path / "input"
+    input_dir.mkdir()
+    file_path = input_dir / "data.txt"
+    file_path.write_text("hello", encoding="utf-8")
+
+    def fake_generate(text):
+        return {"date": "2024-01-01"}
+
+    monkeypatch.setattr(metadata_generation, "generate_metadata", fake_generate)
+
+    dest_root = tmp_path / "Archive"
+
+    with caplog.at_level(logging.INFO):
+        process_directory(input_dir, dest_root)
+
+    assert f"Processing directory {input_dir}" in caplog.text
+    assert f"Processing file {file_path}" in caplog.text
+    assert f"Finished processing {file_path}" in caplog.text


### PR DESCRIPTION
## Summary
- add logging to document processing and text extraction
- cover logging behaviour with tests

## Testing
- `pytest tests/test_logging.py tests/test_docrouter_recursive.py tests/test_file_utils.py tests/test_file_sorter.py tests/test_error_handling.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `pip install httpx` *(fails: Cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68a8308d54bc8330806aaba95e724c51