### PR TITLE
Добавить Dockerfile и docker-compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+__pycache__/
+*.py[cod]
+.git
+.env
+Archive/
+Unsorted/
+logs/
+uploads/
+sorted/
+tests/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.11-slim
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    tesseract-ocr \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 8000
+
+CMD ["python", "main.py"]

--- a/README.md
+++ b/README.md
@@ -35,3 +35,15 @@ export DOCROUTER_PASS=mypass
 
 Все метаданные хранятся в памяти процесса и теряются после перезапуска сервера.
 
+## Docker
+
+Для запуска в контейнере подготовлен `docker-compose.yml`.
+Скопируйте `env.example` в `.env` и поднимите сервис:
+
+```bash
+cp env.example .env
+docker compose up --build
+```
+
+Приложение будет доступно по адресу [http://localhost:8000](http://localhost:8000).
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: "3.9"
+
+services:
+  docrouter:
+    build: .
+    ports:
+      - "8000:8000"
+    env_file:
+      - .env
+    volumes:
+      - ./Archive:/app/Archive


### PR DESCRIPTION
## Summary
- add Dockerfile with tesseract dependency
- add docker-compose for running DocRouter service
- document container usage in README

## Testing
- `pytest` *(fails: The starlette.testclient module requires the httpx package to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68a83342c1b48330aaa10de9ed78531c