### PR TITLE
Обработка отсутствия каталога статики

### DIFF
--- a/src/web_app/server.py
+++ b/src/web_app/server.py
@@ -27,7 +27,13 @@ app = FastAPI()
 # --------- Статика и шаблоны ----------
 STATIC_DIR = Path(__file__).parent / "static"
 TEMPLATES_DIR = Path(__file__).parent / "templates"
-app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
+if STATIC_DIR.exists():
+    app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
+else:  # pragma: no cover
+    logging.getLogger(__name__).warning(
+        "Static directory %s does not exist; static files will not be served.",
+        STATIC_DIR,
+    )
 if Jinja2Templates:
     try:
         templates = Jinja2Templates(directory=TEMPLATES_DIR)


### PR DESCRIPTION
## Summary
- Avoid server crash when `src/web_app/static` is missing by conditionally mounting static files and logging a warning

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a835e7543c8330add838a38ead7957