### PR TITLE
Обработка ошибок анализатора и fallback на RegexAnalyzer

### DIFF
--- a/tests/test_metadata_generation.py
+++ b/tests/test_metadata_generation.py
@@ -1,4 +1,4 @@
-from metadata_generation import generate_metadata
+from metadata_generation import generate_metadata, OpenRouterAnalyzer, RegexAnalyzer
 
 
 def test_generate_metadata_without_api_key(monkeypatch):
@@ -8,3 +8,24 @@ def test_generate_metadata_without_api_key(monkeypatch):
     assert result["date"] == "2023-05-17"
     assert result["amount"] == "123.45"
     assert result["category"] is None
+
+
+def test_fallback_to_regex_on_analyze_error(monkeypatch):
+    def fail(self, text):  # type: ignore[no-redef]
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(OpenRouterAnalyzer, "analyze", fail)
+
+    called: dict[str, bool] = {}
+
+    def fake_regex(self, text):  # type: ignore[no-redef]
+        called["called"] = True
+        return {"category": "regex"}
+
+    monkeypatch.setattr(RegexAnalyzer, "analyze", fake_regex)
+
+    analyzer = OpenRouterAnalyzer(api_key="test")
+    result = generate_metadata("text", analyzer=analyzer)
+
+    assert called.get("called")
+    assert result["category"] == "regex"


### PR DESCRIPTION
## Summary
- логируем ошибки `analyzer.analyze` и переходим на `RegexAnalyzer`
- добавлен тест, проверяющий fallback при исключении `OpenRouterAnalyzer`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a840c2aa7c83308773dca8d55713df