### PR TITLE
Санитизация недопустимых символов в именах документов

### DIFF
--- a/src/file_sorter.py
+++ b/src/file_sorter.py
@@ -2,11 +2,25 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import shutil
 from pathlib import Path
 from typing import Any, Dict
 
 logger = logging.getLogger(__name__)
+
+
+INVALID_CHARS_PATTERN = re.compile(r'[<>:"/\\|?*]')
+
+
+def sanitize_filename(name: str, replacement: str = "_") -> str:
+    """Заменяет недопустимые символы в имени файла.
+
+    :param name: исходное имя (без расширения).
+    :param replacement: символ для подстановки.
+    :return: скорректированное имя.
+    """
+    return INVALID_CHARS_PATTERN.sub(replacement, name)
 
 
 def place_file(src_path: str | Path, metadata: Dict[str, Any], dest_root: str | Path, dry_run: bool = False) -> Path:
@@ -24,6 +38,7 @@ def place_file(src_path: str | Path, metadata: Dict[str, Any], dest_root: str | 
     src = Path(src_path)
     ext = src.suffix
     name = metadata.get("suggested_name") or src.stem
+    name = sanitize_filename(name)
     date = metadata.get("date", "unknown-date")
 
     new_name = f"{date}__{name}{ext}"

--- a/tests/test_file_sorter.py
+++ b/tests/test_file_sorter.py
@@ -42,3 +42,16 @@ def test_place_file_moves_and_creates_json(tmp_path):
     with open(json_path, "r", encoding="utf-8") as f:
         data = json.load(f)
     assert data["issuer"] == "Sparkasse"
+
+
+def test_place_file_sanitizes_invalid_chars(tmp_path):
+    src = tmp_path / "report.pdf"
+    src.write_text("content")
+
+    dest_root = tmp_path / "Archive"
+    metadata = sample_metadata()
+    metadata["suggested_name"] = "inva:lid/na*me?"
+
+    dest = place_file(src, metadata, dest_root, dry_run=True)
+
+    assert dest.name == "2023-10-12__inva_lid_na_me_.pdf"


### PR DESCRIPTION
## Summary
- добавить утилиту `sanitize_filename` для замены запрещённых символов
- использовать её в `place_file` перед формированием имени
- проверить обработку недопустимых символов в тестах

## Testing
- ❌ `.venv/bin/python -m pytest -q` *(не удалось установить pytest: ProxyError 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a840cd44f8833098cdc97a606c72b1