### PR TITLE
feat: add upload progress bar

### DIFF
--- a/src/web_app/static/main.js
+++ b/src/web_app/static/main.js
@@ -1,6 +1,7 @@
 document.addEventListener('DOMContentLoaded', () => {
   const form = document.querySelector('form');
   const list = document.getElementById('files');
+  const progress = document.getElementById('upload-progress');
 
   async function refreshFiles() {
     const resp = await fetch('/files');
@@ -18,16 +19,28 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
-  form.addEventListener('submit', async (e) => {
+  form.addEventListener('submit', (e) => {
     e.preventDefault();
     const data = new FormData(form);
-    const resp = await fetch('/upload', { method: 'POST', body: data });
-    if (resp.ok) {
-      form.reset();
-      refreshFiles();
-    } else {
-      alert('Ошибка загрузки');
-    }
+    progress.value = 0;
+    const xhr = new XMLHttpRequest();
+    xhr.open('POST', '/upload');
+    xhr.upload.addEventListener('progress', (ev) => {
+      if (ev.lengthComputable) {
+        progress.max = ev.total;
+        progress.value = ev.loaded;
+      }
+    });
+    xhr.onload = () => {
+      if (xhr.status === 200) {
+        form.reset();
+        progress.value = 0;
+        refreshFiles();
+      } else {
+        alert('Ошибка загрузки');
+      }
+    };
+    xhr.send(data);
   });
 
   refreshFiles();

--- a/src/web_app/static/style.css
+++ b/src/web_app/static/style.css
@@ -7,3 +7,4 @@ form { display: flex; flex-direction: column; gap: 1em; }
 #files li:last-child { border-bottom: none; }
 button, input[type="submit"] { padding: 0.5em 1em; border: none; background-color: #007bff; color: #fff; border-radius: 4px; cursor: pointer; }
 button:hover, input[type="submit"]:hover { background-color: #0056b3; }
+#upload-progress { width: 100%; margin-top: 1em; }

--- a/src/web_app/templates/index.html
+++ b/src/web_app/templates/index.html
@@ -20,6 +20,7 @@
             </select>
             <input type="submit" value="Upload" />
         </form>
+        <progress id="upload-progress" max="100" value="0"></progress>
         <h2>Загруженные файлы</h2>
         <ul id="files"></ul>
     </div>

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -134,6 +134,7 @@ def test_root_returns_form_unprotected():
         assert resp.status_code == 200
         assert '<form action="/upload" method="post" enctype="multipart/form-data">' in resp.text
         assert 'name="language"' in resp.text
+        assert 'id="upload-progress"' in resp.text
 
 
 def test_files_endpoint_lists_uploaded_files(tmp_path):


### PR DESCRIPTION
## Summary
- add upload progress bar element to index page and style it
- switch upload to XMLHttpRequest and update progress on upload events
- ensure root endpoint renders progress bar in tests

## Testing
- `pytest tests/test_web_app.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a842c0ae348330a10eb278755f498c