### PR TITLE
Добавлено сохранение имени файла

### DIFF
--- a/src/web_app/database.py
+++ b/src/web_app/database.py
@@ -13,10 +13,13 @@ def init_db() -> None:
     _storage.clear()
 
 
-def add_file(file_id: str, metadata: Dict[str, Any], path: str, status: str) -> None:
+def add_file(
+    file_id: str, filename: str, metadata: Dict[str, Any], path: str, status: str
+) -> None:
     """Сохранить информацию о файле."""
     _storage[file_id] = {
         "id": file_id,
+        "filename": filename,
         "metadata": metadata,
         "path": path,
         "status": status,

--- a/src/web_app/server.py
+++ b/src/web_app/server.py
@@ -97,10 +97,11 @@ async def upload_file(
     status = "dry_run" if dry_run else "processed"
 
     # Сохраняем запись в БД
-    database.add_file(file_id, metadata, str(dest_path), status)
+    database.add_file(file_id, file.filename, metadata, str(dest_path), status)
 
     return {
         "id": file_id,
+        "filename": file.filename,
         "metadata": metadata,
         "path": str(dest_path),
         "status": status,

--- a/src/web_app/static/main.js
+++ b/src/web_app/static/main.js
@@ -12,7 +12,8 @@ document.addEventListener('DOMContentLoaded', () => {
       const link = document.createElement('a');
       link.href = `/download/${f.id}`;
       link.textContent = 'скачать';
-      li.innerHTML = `<strong>${f.id}</strong> — ${f.status} `;
+      const category = f.metadata && f.metadata.category ? f.metadata.category : '';
+      li.innerHTML = `<strong>${f.filename}</strong> — ${category} — ${f.status} `;
       li.appendChild(link);
       list.appendChild(li);
     });

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -86,8 +86,9 @@ def test_upload_retrieve_and_download(tmp_path, monkeypatch):
         )
         assert resp.status_code == 200
         data = resp.json()
-        assert {"id", "metadata", "path", "status"} <= set(data.keys())
+        assert {"id", "filename", "metadata", "path", "status"} <= set(data.keys())
         file_id = data["id"]
+        assert data["filename"] == "example.txt"
         assert data["status"] in {"dry_run", "processed"}
         assert data["metadata"]["extracted_text"].strip() == "content"
         assert data["metadata"]["language"] == "deu"
@@ -147,5 +148,8 @@ def test_files_endpoint_lists_uploaded_files(tmp_path):
 
         listing = client.get("/files")
         assert listing.status_code == 200
-        ids = [item["id"] for item in listing.json()]
+        files = listing.json()
+        ids = [item["id"] for item in files]
         assert file_id in ids
+        names = [item["filename"] for item in files]
+        assert "example.txt" in names


### PR DESCRIPTION
## Summary
- сохраняем имя загруженного файла в БД и отдаём его через API
- выводим имя и категорию файла на фронтенде
- обновлены тесты веб-сервиса

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a842cf8fc483309420d8ea05b07545