### PR TITLE
Сохранение prompt и raw_response в метаданных

### DIFF
--- a/src/web_app/database.py
+++ b/src/web_app/database.py
@@ -14,7 +14,13 @@ def init_db() -> None:
 
 
 def add_file(
-    file_id: str, filename: str, metadata: Dict[str, Any], path: str, status: str
+    file_id: str,
+    filename: str,
+    metadata: Dict[str, Any],
+    path: str,
+    status: str,
+    prompt: Any | None = None,
+    raw_response: Any | None = None,
 ) -> None:
     """Сохранить информацию о файле."""
     _storage[file_id] = {
@@ -23,6 +29,8 @@ def add_file(
         "metadata": metadata,
         "path": path,
         "status": status,
+        "prompt": prompt,
+        "raw_response": raw_response,
     }
 
 
@@ -31,11 +39,24 @@ def get_file(file_id: str) -> Optional[Dict[str, Any]]:
     return _storage.get(file_id)
 
 
-def update_file(file_id: str, metadata: Dict[str, Any], path: str, status: str) -> None:
+def update_file(
+    file_id: str,
+    metadata: Dict[str, Any],
+    path: str,
+    status: str,
+    prompt: Any | None = None,
+    raw_response: Any | None = None,
+) -> None:
     """Обновить данные существующей записи."""
     if file_id in _storage:
         _storage[file_id].update(
-            {"metadata": metadata, "path": path, "status": status}
+            {
+                "metadata": metadata,
+                "path": path,
+                "status": status,
+                "prompt": prompt,
+                "raw_response": raw_response,
+            }
         )
 
 

--- a/src/web_app/server.py
+++ b/src/web_app/server.py
@@ -83,7 +83,8 @@ async def upload_file(
         # Извлечение текста + генерация метаданных
         lang = language or config.tesseract_lang
         text = extract_text(temp_path, language=lang)
-        metadata = metadata_generation.generate_metadata(text)
+        meta_result = metadata_generation.generate_metadata(text)
+        metadata = meta_result["metadata"]
         metadata["extracted_text"] = text
         metadata["language"] = lang
 
@@ -97,7 +98,15 @@ async def upload_file(
     status = "dry_run" if dry_run else "processed"
 
     # Сохраняем запись в БД
-    database.add_file(file_id, file.filename, metadata, str(dest_path), status)
+    database.add_file(
+        file_id,
+        file.filename,
+        metadata,
+        str(dest_path),
+        status,
+        meta_result.get("prompt"),
+        meta_result.get("raw_response"),
+    )
 
     return {
         "id": file_id,
@@ -105,6 +114,8 @@ async def upload_file(
         "metadata": metadata,
         "path": str(dest_path),
         "status": status,
+        "prompt": meta_result.get("prompt"),
+        "raw_response": meta_result.get("raw_response"),
     }
 
 

--- a/tests/test_metadata_generation.py
+++ b/tests/test_metadata_generation.py
@@ -5,9 +5,12 @@ def test_generate_metadata_without_api_key(monkeypatch):
     monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
     text = "Total 123.45 on 2023-05-17"
     result = generate_metadata(text)
-    assert result["date"] == "2023-05-17"
-    assert result["amount"] == "123.45"
-    assert result["category"] is None
+    meta = result["metadata"]
+    assert meta["date"] == "2023-05-17"
+    assert meta["amount"] == "123.45"
+    assert meta["category"] is None
+    assert result["prompt"] is None
+    assert result["raw_response"] is None
 
 
 def test_fallback_to_regex_on_analyze_error(monkeypatch):
@@ -20,7 +23,7 @@ def test_fallback_to_regex_on_analyze_error(monkeypatch):
 
     def fake_regex(self, text):  # type: ignore[no-redef]
         called["called"] = True
-        return {"category": "regex"}
+        return {"prompt": None, "raw_response": None, "metadata": {"category": "regex"}}
 
     monkeypatch.setattr(RegexAnalyzer, "analyze", fake_regex)
 
@@ -28,4 +31,4 @@ def test_fallback_to_regex_on_analyze_error(monkeypatch):
     result = generate_metadata("text", analyzer=analyzer)
 
     assert called.get("called")
-    assert result["category"] == "regex"
+    assert result["metadata"]["category"] == "regex"

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -51,16 +51,20 @@ class LiveClient:
 def _mock_generate_metadata(text: str):
     """Детерминированные метаданные для стабильных проверок."""
     return {
-        "category": None,
-        "subcategory": None,
-        "issuer": None,
-        "person": None,
-        "doc_type": None,
-        "date": "2024-01-01",
-        "amount": None,
-        "tags": [],
-        "suggested_filename": None,
-        "description": None,
+        "prompt": "PROMPT",
+        "raw_response": "{\"date\": \"2024-01-01\"}",
+        "metadata": {
+            "category": None,
+            "subcategory": None,
+            "issuer": None,
+            "person": None,
+            "doc_type": None,
+            "date": "2024-01-01",
+            "amount": None,
+            "tags": [],
+            "suggested_filename": None,
+            "description": None,
+        },
     }
 
 
@@ -86,13 +90,15 @@ def test_upload_retrieve_and_download(tmp_path, monkeypatch):
         )
         assert resp.status_code == 200
         data = resp.json()
-        assert {"id", "filename", "metadata", "path", "status"} <= set(data.keys())
+        assert {"id", "filename", "metadata", "path", "status", "prompt", "raw_response"} <= set(data.keys())
         file_id = data["id"]
         assert data["filename"] == "example.txt"
         assert data["status"] in {"dry_run", "processed"}
         assert data["metadata"]["extracted_text"].strip() == "content"
         assert data["metadata"]["language"] == "deu"
         assert captured["language"] == "deu"
+        assert data["prompt"] == "PROMPT"
+        assert data["raw_response"] == "{\"date\": \"2024-01-01\"}"
 
         # Чтение метаданных
         meta = client.get(f"/metadata/{file_id}")


### PR DESCRIPTION
## Summary
- Возврат структуры с prompt, raw_response и metadata при генерации метаданных
- Сохранение prompt и raw_response в базе и ответе /upload
- Тесты проверяют наличие новых полей

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a843ecb32c8330976ce352f720f591