### PR TITLE
Добавлена панель обмена с ИИ

### DIFF
--- a/src/web_app/static/main.js
+++ b/src/web_app/static/main.js
@@ -2,6 +2,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const form = document.querySelector('form');
   const list = document.getElementById('files');
   const progress = document.getElementById('upload-progress');
+  const sent = document.getElementById('ai-sent');
+  const received = document.getElementById('ai-received');
 
   async function refreshFiles() {
     const resp = await fetch('/files');
@@ -34,6 +36,9 @@ document.addEventListener('DOMContentLoaded', () => {
     });
     xhr.onload = () => {
       if (xhr.status === 200) {
+        const result = JSON.parse(xhr.responseText);
+        sent.textContent = result.prompt || '';
+        received.textContent = result.raw_response || '';
         form.reset();
         progress.value = 0;
         refreshFiles();

--- a/src/web_app/static/style.css
+++ b/src/web_app/static/style.css
@@ -8,3 +8,5 @@ form { display: flex; flex-direction: column; gap: 1em; }
 button, input[type="submit"] { padding: 0.5em 1em; border: none; background-color: #007bff; color: #fff; border-radius: 4px; cursor: pointer; }
 button:hover, input[type="submit"]:hover { background-color: #0056b3; }
 #upload-progress { width: 100%; margin-top: 1em; }
+#ai-exchange { max-height: 200px; overflow-y: auto; font-family: monospace; background: #f0f0f0; padding: 1em; border: 1px solid #ddd; margin-top: 1em; }
+#ai-exchange pre { white-space: pre-wrap; margin: 0 0 1em 0; }

--- a/src/web_app/templates/index.html
+++ b/src/web_app/templates/index.html
@@ -23,6 +23,12 @@
         <progress id="upload-progress" max="100" value="0"></progress>
         <h2>Загруженные файлы</h2>
         <ul id="files"></ul>
+        <div id="ai-exchange">
+            <h3>Отправлено</h3>
+            <pre id="ai-sent"></pre>
+            <h3>Получено</h3>
+            <pre id="ai-received"></pre>
+        </div>
     </div>
 </body>
 </html>

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -171,6 +171,7 @@ def test_root_returns_form_unprotected():
         assert '<form action="/upload" method="post" enctype="multipart/form-data">' in resp.text
         assert 'name="language"' in resp.text
         assert 'id="upload-progress"' in resp.text
+        assert 'id="ai-exchange"' in resp.text
 
 
 def test_files_endpoint_lists_uploaded_files(tmp_path):


### PR DESCRIPTION
## Summary
- добавить на главную страницу панель `#ai-exchange` для отображения промпта и ответа модели
- заполнять панель данными после загрузки файла
- оформить панель стилями и покрыть наличие блока тестом

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a84628e4208330a68409c4953bb264