### PR TITLE
Добавлен вывод дерева папок в веб-интерфейсе

### DIFF
--- a/src/web_app/server.py
+++ b/src/web_app/server.py
@@ -154,3 +154,9 @@ async def get_file_details(file_id: str):
 async def list_files():
     """Вернуть список всех загруженных файлов."""
     return database.list_files()
+
+
+@app.get("/folder-tree")
+async def folder_tree():
+    """Вернуть структуру папок в выходном каталоге."""
+    return get_folder_tree(config.output_dir)

--- a/src/web_app/static/main.js
+++ b/src/web_app/static/main.js
@@ -1,6 +1,7 @@
 document.addEventListener('DOMContentLoaded', () => {
   const form = document.querySelector('form');
   const list = document.getElementById('files');
+  const folderTree = document.getElementById('folder-tree');
   const progress = document.getElementById('upload-progress');
   const sent = document.getElementById('ai-sent');
   const received = document.getElementById('ai-received');
@@ -20,6 +21,28 @@ document.addEventListener('DOMContentLoaded', () => {
       li.appendChild(link);
       list.appendChild(li);
     });
+  }
+
+  function renderTree(container, tree) {
+    Object.keys(tree).forEach(key => {
+      const li = document.createElement('li');
+      li.textContent = key;
+      const children = tree[key];
+      if (children && Object.keys(children).length > 0) {
+        const ul = document.createElement('ul');
+        renderTree(ul, children);
+        li.appendChild(ul);
+      }
+      container.appendChild(li);
+    });
+  }
+
+  async function refreshFolderTree() {
+    const resp = await fetch('/folder-tree');
+    if (!resp.ok) return;
+    const tree = await resp.json();
+    folderTree.innerHTML = '';
+    renderTree(folderTree, tree);
   }
 
   form.addEventListener('submit', (e) => {
@@ -42,6 +65,7 @@ document.addEventListener('DOMContentLoaded', () => {
         form.reset();
         progress.value = 0;
         refreshFiles();
+        refreshFolderTree();
       } else {
         alert('Ошибка загрузки');
       }
@@ -50,4 +74,5 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   refreshFiles();
+  refreshFolderTree();
 });

--- a/src/web_app/templates/index.html
+++ b/src/web_app/templates/index.html
@@ -21,6 +21,8 @@
             <input type="submit" value="Upload" />
         </form>
         <progress id="upload-progress" max="100" value="0"></progress>
+        <h2>Структура папок</h2>
+        <ul id="folder-tree"></ul>
         <h2>Загруженные файлы</h2>
         <ul id="files"></ul>
         <div id="ai-exchange">

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -172,6 +172,7 @@ def test_root_returns_form_unprotected():
         assert 'name="language"' in resp.text
         assert 'id="upload-progress"' in resp.text
         assert 'id="ai-exchange"' in resp.text
+        assert 'id="folder-tree"' in resp.text
 
 
 def test_files_endpoint_lists_uploaded_files(tmp_path):


### PR DESCRIPTION
## Summary
- Добавлен блок `#folder-tree` на главной странице и запрос дерева папок из фронтенда
- Реализован эндпоинт `GET /folder-tree` на сервере
- Тесты проверяют наличие дерева папок на странице

## Testing
- `pytest tests/test_web_app.py`

------
https://chatgpt.com/codex/tasks/task_e_68a8479b02b8833082bffd8a6b1dc863