### PR TITLE
Добавление управления папками на фронтенде

### DIFF
--- a/src/web_app/templates/index.html
+++ b/src/web_app/templates/index.html
@@ -23,6 +23,23 @@
         <progress id="upload-progress" max="100" value="0"></progress>
         <h2>Структура папок</h2>
         <ul id="folder-tree"></ul>
+        <div id="folder-ops">
+            <h3>Управление папками</h3>
+            <form id="create-folder-form">
+                <input type="text" id="create-folder-path" placeholder="Новая папка" />
+                <button type="submit">Создать</button>
+            </form>
+            <form id="rename-folder-form">
+                <input type="text" id="rename-folder-old" placeholder="Текущий путь" />
+                <input type="text" id="rename-folder-new" placeholder="Новое имя" />
+                <button type="submit">Переименовать</button>
+            </form>
+            <form id="delete-folder-form">
+                <input type="text" id="delete-folder-path" placeholder="Путь к папке" />
+                <button type="submit">Удалить</button>
+            </form>
+            <div id="folder-message"></div>
+        </div>
         <h2>Загруженные файлы</h2>
         <ul id="files"></ul>
         <div id="ai-exchange">


### PR DESCRIPTION
## Summary
- добавлены функции createFolder, renameFolder и deleteFolder с обращением к API и обработкой ошибок
- добавлены формы управления папками на главной странице и привязаны обработчики

## Testing
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68a8497a31148330a77f99200d724593