### PR TITLE
feat: expose path info in folder tree

### DIFF
--- a/src/web_app/server.py
+++ b/src/web_app/server.py
@@ -168,7 +168,10 @@ async def list_files():
 
 @app.get("/folder-tree")
 async def folder_tree():
-    """Вернуть структуру папок в выходном каталоге."""
+    """Вернуть структуру папок в выходном каталоге.
+
+    Каждый элемент содержит поля ``name``, ``path`` и ``children``.
+    """
     return get_folder_tree(config.output_dir)
 
 

--- a/tests/test_metadata_generation.py
+++ b/tests/test_metadata_generation.py
@@ -54,7 +54,15 @@ def test_folder_tree_in_prompt(monkeypatch):
     monkeypatch.setattr("metadata_generation.requests.post", fake_post)
 
     analyzer = OpenRouterAnalyzer(api_key="test")
-    tree = {"Финансы": {"Банки": {}}}
+    tree = [
+        {
+            "name": "Финансы",
+            "path": "Финансы",
+            "children": [
+                {"name": "Банки", "path": "Финансы/Банки", "children": []}
+            ],
+        }
+    ]
     result = generate_metadata("text", analyzer=analyzer, folder_tree=tree)
 
     tree_json = json.dumps(tree, ensure_ascii=False)

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -204,12 +204,34 @@ def test_folder_crud_operations(tmp_path):
     with LiveClient(app) as client:
         resp = client.post("/folders", params={"path": "a/b"})
         assert resp.status_code == 200
-        assert resp.json() == {"a": {"b": {}}}
+        assert resp.json() == [
+            {
+                "name": "a",
+                "path": "a",
+                "children": [
+                    {"name": "b", "path": "a/b", "children": []}
+                ],
+            }
+        ]
 
         resp = client.patch("/folders/a/b", params={"new_name": "c"})
         assert resp.status_code == 200
-        assert resp.json() == {"a": {"c": {}}}
+        assert resp.json() == [
+            {
+                "name": "a",
+                "path": "a",
+                "children": [
+                    {"name": "c", "path": "a/c", "children": []}
+                ],
+            }
+        ]
 
         resp = client.delete("/folders/a/c")
         assert resp.status_code == 200
-        assert resp.json() == {"a": {}}
+        assert resp.json() == [
+            {
+                "name": "a",
+                "path": "a",
+                "children": [],
+            }
+        ]


### PR DESCRIPTION
## Summary
- return name and path for each node in folder tree
- document new structure in folder tree API
- update tests for new folder tree format

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8496a07408330abf3704fee6a0c8a