### PR TITLE
feat: add create_missing option to place_file

### DIFF
--- a/src/web_app/server.py
+++ b/src/web_app/server.py
@@ -100,7 +100,10 @@ async def upload_file(
         metadata["language"] = lang
 
         # Раскладываем файл по директориям
-        dest_path = place_file(str(temp_path), metadata, config.output_dir, dry_run=dry_run)
+        dest_result = place_file(
+            str(temp_path), metadata, config.output_dir, dry_run=dry_run
+        )
+        dest_path = dest_result["path"] if isinstance(dest_result, dict) else dest_result
 
     except Exception as exc:  # pragma: no cover
         logger.exception("Upload/processing failed for %s", file.filename)

--- a/tests/test_file_sorter.py
+++ b/tests/test_file_sorter.py
@@ -55,3 +55,25 @@ def test_place_file_sanitizes_invalid_chars(tmp_path):
     dest = place_file(src, metadata, dest_root, dry_run=True)
 
     assert dest.name == "2023-10-12__inva_lid_na_me_.pdf"
+
+
+def test_place_file_reports_missing(tmp_path):
+    src = tmp_path / "doc.pdf"
+    src.write_text("content")
+
+    dest_root = tmp_path / "Archive"
+    dest_root.mkdir()
+
+    result = place_file(
+        src, sample_metadata(), dest_root, dry_run=False, create_missing=False
+    )
+
+    expected_path = dest_root / "Финансы" / "Банки" / "Sparkasse" / "2023-10-12__Kreditvertrag.pdf"
+    assert result["path"] == expected_path
+    assert result["missing"] == [
+        dest_root / "Финансы",
+        dest_root / "Финансы" / "Банки",
+        dest_root / "Финансы" / "Банки" / "Sparkasse",
+    ]
+    # Файл не должен быть перемещён
+    assert src.exists()


### PR DESCRIPTION
## Summary
- allow skipping directory creation via `create_missing` flag in `place_file`
- update web app to handle new return type
- test reporting of missing directories

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a84f5704ec833085d24130ef261d41