### PR TITLE
Handle pending uploads when folders missing

### DIFF
--- a/src/web_app/database.py
+++ b/src/web_app/database.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 """Простейшее хранилище метаданных в памяти."""
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, List
 
 # Внутренний словарь для хранения записей
 _storage: Dict[str, Dict[str, Any]] = {}
@@ -21,6 +21,7 @@ def add_file(
     status: str,
     prompt: Any | None = None,
     raw_response: Any | None = None,
+    missing: Optional[List[str]] = None,
 ) -> None:
     """Сохранить информацию о файле."""
     _storage[file_id] = {
@@ -31,6 +32,7 @@ def add_file(
         "status": status,
         "prompt": prompt,
         "raw_response": raw_response,
+        "missing": missing or [],
     }
 
 
@@ -51,6 +53,7 @@ def update_file(
     status: str,
     prompt: Any | None = None,
     raw_response: Any | None = None,
+    missing: Optional[List[str]] = None,
 ) -> None:
     """Обновить данные существующей записи."""
     if file_id in _storage:
@@ -61,6 +64,7 @@ def update_file(
                 "status": status,
                 "prompt": prompt,
                 "raw_response": raw_response,
+                "missing": missing or [],
             }
         )
 

--- a/tests/test_file_sorter.py
+++ b/tests/test_file_sorter.py
@@ -23,7 +23,7 @@ def test_place_file_path_and_name(tmp_path, capsys):
     src.write_text("data")
 
     dest_root = tmp_path / "Archive"
-    dest = place_file(src, sample_metadata(), dest_root, dry_run=True)
+    dest, _ = place_file(src, sample_metadata(), dest_root, dry_run=True)
 
     expected = dest_root / "Финансы" / "Банки" / "Sparkasse" / "2023-10-12__Kreditvertrag.pdf"
     assert dest == expected
@@ -34,11 +34,12 @@ def test_place_file_moves_and_creates_json(tmp_path):
     src.write_text("content")
 
     dest_root = tmp_path / "Archive"
-    dest = place_file(src, sample_metadata(), dest_root, dry_run=False)
+    dest, missing = place_file(src, sample_metadata(), dest_root, dry_run=False)
 
     json_path = dest.with_suffix(dest.suffix + ".json")
     assert dest.exists()
     assert json_path.exists()
+    assert missing == []
     with open(json_path, "r", encoding="utf-8") as f:
         data = json.load(f)
     assert data["issuer"] == "Sparkasse"
@@ -52,6 +53,24 @@ def test_place_file_sanitizes_invalid_chars(tmp_path):
     metadata = sample_metadata()
     metadata["suggested_name"] = "inva:lid/na*me?"
 
-    dest = place_file(src, metadata, dest_root, dry_run=True)
+    dest, _ = place_file(src, metadata, dest_root, dry_run=True)
 
     assert dest.name == "2023-10-12__inva_lid_na_me_.pdf"
+
+
+def test_place_file_returns_missing_dirs(tmp_path):
+    src = tmp_path / "document.pdf"
+    src.write_text("content")
+
+    dest_root = tmp_path / "Archive"
+    dest, missing = place_file(
+        src, sample_metadata(), dest_root, dry_run=False, create_missing=False
+    )
+
+    assert missing == [
+        "Финансы",
+        "Финансы/Банки",
+        "Финансы/Банки/Sparkasse",
+    ]
+    assert not dest.exists()
+    assert src.exists()


### PR DESCRIPTION
## Summary
- allow `place_file` to report missing directories without moving files
- track missing folders in web API and add finalize endpoint
- cover pending upload and finalize flow with tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a84f63e1a88330858d0f2d37d9e233