### PR TITLE
Install Russian Tesseract language data in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,11 @@ FROM python:3.11-slim
 # Install system dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
     tesseract-ocr \
+    tesseract-ocr-rus \
     && rm -rf /var/lib/apt/lists/*
+
+# Ensure Tesseract can locate language data
+ENV TESSDATA_PREFIX=/usr/share/tesseract-ocr/5/tessdata
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- install tesseract-ocr-rus so OCR works for Russian documents
- set `TESSDATA_PREFIX` to tesseract data path

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a84e44d5a883309baa8d6b968e0705