### PR TITLE
feat: add images upload endpoint

### DIFF
--- a/src/docrouter.py
+++ b/src/docrouter.py
@@ -30,6 +30,7 @@ def process_directory(input_dir: str | Path, dest_root: str | Path, dry_run: boo
             metadata = metadata_generation.generate_metadata(text)
             rel_dir = path.parent.relative_to(input_path)
             dest_base = Path(dest_root) / rel_dir
+            dest_base.mkdir(parents=True, exist_ok=True)
             place_file(path, metadata, dest_base, dry_run=dry_run)
             logger.info("Finished processing %s", path)
         except Exception as exc:  # pragma: no cover - depending on runtime errors

--- a/src/file_utils/__init__.py
+++ b/src/file_utils/__init__.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Callable, Dict, Union
 import csv
 import logging
+from PIL import Image
 
 # Опциональные зависимости
 try:
@@ -154,6 +155,23 @@ def extract_text(file_path: Union[str, Path], language: str = "eng") -> str:
     return text
 
 
+# ---------- Вспомогательные утилиты ----------
+
+def merge_images_to_pdf(image_paths: list[Path], output_pdf: Path) -> Path:
+    """Объединить изображения в один PDF.
+
+    :param image_paths: список путей к изображениям.
+    :param output_pdf: путь к результирующему PDF.
+    :return: путь к созданному PDF.
+    """
+    images = [Image.open(p).convert("RGB") for p in image_paths]
+    if not images:
+        raise ValueError("No images provided")
+    first, *rest = images
+    first.save(output_pdf, save_all=True, append_images=rest, format="PDF")
+    return output_pdf
+
+
 __all__ = [
     "extract_text",
     "extract_text_txt",
@@ -163,4 +181,5 @@ __all__ = [
     "extract_text_csv",
     "extract_text_xls",
     "extract_text_xlsx",
+    "merge_images_to_pdf",
 ]

--- a/src/web_app/database.py
+++ b/src/web_app/database.py
@@ -22,6 +22,7 @@ def add_file(
     prompt: Any | None = None,
     raw_response: Any | None = None,
     missing: Optional[List[str]] = None,
+    sources: Optional[List[str]] = None,
 ) -> None:
     """Сохранить информацию о файле."""
     _storage[file_id] = {
@@ -34,6 +35,8 @@ def add_file(
         "raw_response": raw_response,
         "missing": missing or [],
     }
+    if sources is not None:
+        _storage[file_id]["sources"] = sources
 
 
 def get_file(file_id: str) -> Optional[Dict[str, Any]]:
@@ -54,6 +57,7 @@ def update_file(
     prompt: Any | None = None,
     raw_response: Any | None = None,
     missing: Optional[List[str]] = None,
+    sources: Optional[List[str]] = None,
 ) -> None:
     """Обновить данные существующей записи."""
     if file_id in _storage:
@@ -67,6 +71,8 @@ def update_file(
                 "missing": missing or [],
             }
         )
+        if sources is not None:
+            _storage[file_id]["sources"] = sources
 
 
 def delete_file(file_id: str) -> None:

--- a/src/web_app/server.py
+++ b/src/web_app/server.py
@@ -15,7 +15,7 @@ except Exception:  # pragma: no cover
 
 from config import load_config
 from logging_config import setup_logging
-from file_utils import extract_text
+from file_utils import extract_text, merge_images_to_pdf
 from file_sorter import place_file, get_folder_tree
 import metadata_generation
 from . import database
@@ -149,6 +149,98 @@ async def upload_file(
         "missing": [],
         "prompt": meta_result.get("prompt"),
         "raw_response": meta_result.get("raw_response"),
+    }
+
+
+@app.post("/upload/images")
+async def upload_images(
+    files: list[UploadFile] = File(...),
+    language: str | None = Form(None),
+    dry_run: bool = False,
+):
+    """Загрузить несколько изображений, объединить их и обработать как PDF."""
+    file_id = str(uuid.uuid4())
+    temp_dir = UPLOAD_DIR / file_id
+    temp_dir.mkdir(exist_ok=True)
+
+    sorted_files = sorted(files, key=lambda f: f.filename or "")
+    image_paths: list[Path] = []
+    for idx, img in enumerate(sorted_files):
+        temp_img = temp_dir / f"{idx:03d}_{img.filename}"
+        contents = await img.read()
+        with open(temp_img, "wb") as dest:
+            dest.write(contents)
+        image_paths.append(temp_img)
+
+    pdf_path = UPLOAD_DIR / f"{file_id}.pdf"
+    try:
+        merge_images_to_pdf(image_paths, pdf_path)
+    except Exception as exc:  # pragma: no cover
+        shutil.rmtree(temp_dir, ignore_errors=True)
+        logger.exception("Failed to merge images: %s", [f.filename for f in files])
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+    shutil.rmtree(temp_dir, ignore_errors=True)
+
+    try:
+        lang = language or config.tesseract_lang
+        text = extract_text(pdf_path, language=lang)
+        folder_tree = get_folder_tree(config.output_dir)
+        meta_result = metadata_generation.generate_metadata(text, folder_tree=folder_tree)
+        metadata = meta_result["metadata"]
+        metadata["extracted_text"] = text
+        metadata["language"] = lang
+
+        dest_path, missing = place_file(
+            str(pdf_path),
+            metadata,
+            config.output_dir,
+            dry_run=dry_run,
+            create_missing=False,
+        )
+    except Exception as exc:  # pragma: no cover
+        logger.exception("Upload/processing failed for images")
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+    sources = [f.filename for f in sorted_files]
+
+    if missing:
+        database.add_file(
+            file_id,
+            pdf_path.name,
+            metadata,
+            str(pdf_path),
+            "pending",
+            meta_result.get("prompt"),
+            meta_result.get("raw_response"),
+            missing,
+            sources=sources,
+        )
+        return {"id": file_id, "status": "pending", "missing": missing, "sources": sources}
+
+    status = "dry_run" if dry_run else "processed"
+    database.add_file(
+        file_id,
+        pdf_path.name,
+        metadata,
+        str(dest_path),
+        status,
+        meta_result.get("prompt"),
+        meta_result.get("raw_response"),
+        [],
+        sources=sources,
+    )
+
+    return {
+        "id": file_id,
+        "filename": pdf_path.name,
+        "metadata": metadata,
+        "path": str(dest_path),
+        "status": status,
+        "missing": [],
+        "prompt": meta_result.get("prompt"),
+        "raw_response": meta_result.get("raw_response"),
+        "sources": sources,
     }
 
 

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -129,6 +129,48 @@ def test_upload_retrieve_and_download(tmp_path, monkeypatch):
         assert download.content == b"content"
 
 
+def test_upload_images_returns_sources(tmp_path, monkeypatch):
+    server.database.init_db()
+
+    captured = {}
+
+    def _mock_merge(paths, dest):
+        captured["paths"] = [Path(p).name for p in paths]
+        with open(dest, "wb") as f:
+            f.write(b"PDF")
+        return dest
+
+    def _mock_extract_text(path, language="eng"):
+        captured["language"] = language
+        return "pdf text"
+
+    monkeypatch.setattr(server, "merge_images_to_pdf", _mock_merge)
+    monkeypatch.setattr(server, "extract_text", _mock_extract_text)
+    monkeypatch.setattr(server.metadata_generation, "generate_metadata", _mock_generate_metadata)
+    server.config.output_dir = str(tmp_path)
+
+    with LiveClient(app) as client:
+        files = [
+            ("files", ("b.jpg", b"1", "image/jpeg")),
+            ("files", ("a.jpg", b"2", "image/jpeg")),
+        ]
+        resp = client.post(
+            "/upload/images",
+            data={"language": "deu"},
+            files=files,
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["sources"] == ["a.jpg", "b.jpg"]
+        assert data["metadata"]["language"] == "deu"
+        assert captured["language"] == "deu"
+        file_id = data["id"]
+
+        record = server.database.get_file(file_id)
+        assert record and record["sources"] == ["a.jpg", "b.jpg"]
+        assert Path(record["path"]).exists()
+
+
 def test_details_endpoint_returns_full_record(tmp_path, monkeypatch):
     server.database.init_db()
 


### PR DESCRIPTION
## Summary
- add merge_images_to_pdf helper
- support sources field in metadata storage
- allow uploading multiple images, merge to PDF and process
- ensure recursive processing creates destination directories

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a854d9f40c8330a7b010b9441fb0db