### PR TITLE
feat: merge images to pdf

### DIFF
--- a/src/web_app/server.py
+++ b/src/web_app/server.py
@@ -175,9 +175,10 @@ async def upload_images(
             dest.write(contents)
         image_paths.append(temp_img)
 
-    pdf_path = UPLOAD_DIR / f"{file_id}.pdf"
     try:
-        merge_images_to_pdf(image_paths, pdf_path)
+        tmp_pdf = merge_images_to_pdf(image_paths)
+        pdf_path = UPLOAD_DIR / f"{file_id}.pdf"
+        shutil.move(tmp_pdf, pdf_path)
     except Exception as exc:  # pragma: no cover
         shutil.rmtree(temp_dir, ignore_errors=True)
         logger.exception("Failed to merge images: %s", [f.filename for f in files])

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -134,11 +134,11 @@ def test_upload_images_returns_sources(tmp_path, monkeypatch):
 
     captured = {}
 
-    def _mock_merge(paths, dest):
+    def _mock_merge(paths):
         captured["paths"] = [Path(p).name for p in paths]
-        with open(dest, "wb") as f:
-            f.write(b"PDF")
-        return dest
+        tmp_file = tmp_path / "tmp.pdf"
+        tmp_file.write_bytes(b"PDF")
+        return tmp_file
 
     def _mock_extract_text(path, language="eng"):
         captured["language"] = language


### PR DESCRIPTION
## Summary
- add `merge_images_to_pdf` utility to merge images into a temporary PDF
- adjust web server to use the new PDF merge helper
- test PDF merge with mixed image formats

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8575dd24883308841ccbec6097187