### PR TITLE
feat: add batch image upload UI

### DIFF
--- a/src/web_app/static/style.css
+++ b/src/web_app/static/style.css
@@ -23,3 +23,8 @@ button:hover, input[type="submit"]:hover { background-color: #0056b3; }
   #missing-list li { margin: 0.2em 0; }
 #preview-modal .modal-content { width: 80%; height: 80%; max-width: 1000px; max-height: 800px; }
 #preview-frame { width: 100%; height: 100%; border: none; }
+
+#image-drop-area { border: 2px dashed #007bff; padding: 1em; text-align: center; margin-top: 1em; background: #fafafa; cursor: pointer; }
+#image-drop-area.dragover { background: #e0e0e0; }
+#selected-images { list-style: none; padding: 0; margin-top: 1em; }
+#selected-images li { margin: 0.2em 0; }

--- a/src/web_app/templates/index.html
+++ b/src/web_app/templates/index.html
@@ -21,6 +21,15 @@
             <input type="submit" value="Upload" />
         </form>
         <progress id="upload-progress" max="100" value="0"></progress>
+        <div id="image-upload-block">
+            <h2>Загрузить набор изображений</h2>
+            <div id="image-drop-area">
+                <p>Перетащите JPEG-файлы сюда или выберите их вручную</p>
+                <input id="image-files" type="file" multiple accept="image/jpeg" />
+            </div>
+            <ul id="selected-images"></ul>
+            <button id="upload-images-btn" type="button">Загрузить набор изображений</button>
+        </div>
         <h2>Структура папок</h2>
         <div id="folder-controls">
             <input type="text" id="new-folder-name" placeholder="Имя папки">


### PR DESCRIPTION
## Summary
- add image batch upload block with drag-and-drop area
- handle sending multiple JPEGs to `/upload/images`
- style drop zone and selected file list

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a858754b0c83309768539b80b5acd8