### PR TITLE
Add chat modal and server endpoint with history

### DIFF
--- a/src/web_app/database.py
+++ b/src/web_app/database.py
@@ -34,6 +34,7 @@ def add_file(
         "prompt": prompt,
         "raw_response": raw_response,
         "missing": missing or [],
+        "chat_history": [],
     }
     if sources is not None:
         _storage[file_id]["sources"] = sources
@@ -87,4 +88,22 @@ def delete_file(file_id: str) -> None:
 def list_files() -> list[Dict[str, Any]]:
     """Получить список всех файлов."""
     return list(_storage.values())
+
+
+def add_chat_message(file_id: str, role: str, message: str) -> List[Dict[str, str]]:
+    """Добавить запись в историю чата."""
+    record = _storage.get(file_id)
+    if record is None:
+        return []
+    history: List[Dict[str, str]] = record.setdefault("chat_history", [])
+    history.append({"role": role, "message": message})
+    return history
+
+
+def get_chat_history(file_id: str) -> List[Dict[str, str]]:
+    """Получить историю чата по файлу."""
+    record = _storage.get(file_id)
+    if record is None:
+        return []
+    return record.setdefault("chat_history", [])
 

--- a/src/web_app/server.py
+++ b/src/web_app/server.py
@@ -437,3 +437,18 @@ async def finalize_file(
         still_missing,
     )
     return database.get_file(file_id)
+
+
+@app.post("/chat/{file_id}")
+async def chat(file_id: str, message: str = Body(..., embed=True)):
+    """Простой чат с учётом текста файла."""
+    record = database.get_file(file_id)
+    if not record:
+        raise HTTPException(status_code=404, detail="File not found")
+
+    text = record.get("metadata", {}).get("extracted_text", "")
+    reply = f"Эхо: {message} | {text}".strip()
+
+    database.add_chat_message(file_id, "user", message)
+    history = database.add_chat_message(file_id, "assistant", reply)
+    return {"response": reply, "chat_history": history}

--- a/src/web_app/templates/index.html
+++ b/src/web_app/templates/index.html
@@ -104,5 +104,15 @@
             <iframe id="preview-frame"></iframe>
         </div>
     </div>
+    <div id="chat-modal" class="modal">
+        <div class="modal-content">
+            <span class="close" data-close="chat-modal">&times;</span>
+            <div id="chat-history"></div>
+            <form id="chat-form">
+                <input type="text" id="chat-input" placeholder="Сообщение" />
+                <button type="submit">Отправить</button>
+            </form>
+        </div>
+    </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add in-memory chat history storage and endpoint
- create chat modal and frontend logic
- cover chat workflow with tests

## Testing
- `pytest tests/test_web_app.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a85a2d42dc8330a6828b202c8d0b94