### PR TITLE
Добавлен парсер MRZ и поддержка дат паспорта

### DIFF
--- a/src/file_utils/__init__.py
+++ b/src/file_utils/__init__.py
@@ -43,6 +43,8 @@ try:
 except Exception:  # pragma: no cover - optional module
     extract_text_image = None  # type: ignore
 
+from .mrz import parse_mrz
+
 logger = logging.getLogger(__name__)
 
 
@@ -214,6 +216,7 @@ __all__ = [
     "extract_text_xls",
     "extract_text_xlsx",
     "merge_images_to_pdf",
+    "parse_mrz",
     "translate_text",
 ]
 

--- a/src/file_utils/mrz.py
+++ b/src/file_utils/mrz.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import re
+from datetime import datetime
+from typing import Dict
+
+__all__ = ["parse_mrz"]
+
+# Регулярное выражение для MRZ паспортов (формат TD3)
+MRZ_PASSPORT_RE = re.compile(
+    r"P<(?P<country>[A-Z]{3})(?P<names>[A-Z<]+)\n"
+    r"(?P<passport_number>[A-Z0-9<]{9})(?P<passport_check>\d)"
+    r"[A-Z]{3}"
+    r"(?P<birth_date>\d{6})(?P<birth_check>\d)"
+    r"(?P<sex>[MF<])"
+    r"(?P<expiration_date>\d{6})(?P<exp_check>\d)"
+    r"[A-Z0-9<]+",
+)
+
+
+def _format_date(raw: str) -> str | None:
+    """Преобразовать дату из формата YYMMDD в ISO YYYY-MM-DD."""
+    if not re.fullmatch(r"\d{6}", raw):
+        return None
+    year = int(raw[0:2])
+    month = int(raw[2:4])
+    day = int(raw[4:6])
+    # Примитивная эвристика определения века
+    century = 1900 if year >= 50 else 2000
+    try:
+        dt = datetime(century + year, month, day)
+        return dt.strftime("%Y-%m-%d")
+    except ValueError:
+        return None
+
+
+def parse_mrz(text: str) -> Dict[str, str | None]:
+    """Извлечь основные поля из MRZ (Machine Readable Zone).
+
+    Поддерживается стандартный формат паспортов (TD3).
+    Возвращает словарь с ключами ``passport_number``, ``person``,
+    ``date_of_birth`` и ``expiration_date``. Если MRZ не найден,
+    возвращается пустой словарь.
+    """
+
+    # Упрощённая нормализация: приводим к верхнему регистру и убираем пробелы
+    normalized = "\n".join(line.strip().replace(" ", "") for line in text.upper().splitlines())
+    match = MRZ_PASSPORT_RE.search(normalized)
+    if not match:
+        return {}
+
+    names = match.group("names")
+    parts = names.split("<<")
+    surname = parts[0].replace("<", " ").strip()
+    given = parts[1].replace("<", " ").strip() if len(parts) > 1 else ""
+    person = f"{given} {surname}".strip()
+
+    passport_number = match.group("passport_number") + match.group("passport_check")
+    passport_number = passport_number.replace("<", "")
+
+    dob = _format_date(match.group("birth_date"))
+    exp = _format_date(match.group("expiration_date"))
+
+    return {
+        "passport_number": passport_number or None,
+        "person": person or None,
+        "date_of_birth": dob,
+        "expiration_date": exp,
+    }

--- a/src/metadata_generation.py
+++ b/src/metadata_generation.py
@@ -24,6 +24,8 @@ from config import (
     OPENROUTER_SITE_URL,
 )
 
+from file_utils.mrz import parse_mrz
+
 
 logger = logging.getLogger(__name__)
 
@@ -169,6 +171,9 @@ def generate_metadata(
         "person": None,
         "doc_type": None,
         "date": None,
+        "date_of_birth": None,
+        "expiration_date": None,
+        "passport_number": None,
         "amount": None,
         "tags": [],
         "tags_ru": [],
@@ -178,6 +183,13 @@ def generate_metadata(
         "needs_new_folder": False,
     }
     defaults.update(metadata or {})
+    mrz_info = parse_mrz(text)
+    if mrz_info:
+        if defaults.get("person") in (None, "") and mrz_info.get("person"):
+            defaults["person"] = mrz_info["person"]
+        for key in ("date_of_birth", "expiration_date", "passport_number"):
+            if mrz_info.get(key):
+                defaults[key] = mrz_info[key]
     return {
         "prompt": result.get("prompt"),
         "raw_response": result.get("raw_response"),

--- a/src/web_app/database.py
+++ b/src/web_app/database.py
@@ -34,6 +34,10 @@ def add_file(
         "metadata": metadata,
         "tags_ru": metadata.get("tags_ru", []),
         "tags_en": metadata.get("tags_en", []),
+        "person": metadata.get("person"),
+        "date_of_birth": metadata.get("date_of_birth"),
+        "expiration_date": metadata.get("expiration_date"),
+        "passport_number": metadata.get("passport_number"),
         "path": path,
         "status": status,
         "prompt": prompt,
@@ -83,6 +87,14 @@ def update_file(
             record["tags_ru"] = metadata["tags_ru"]
         if "tags_en" in metadata:
             record["tags_en"] = metadata["tags_en"]
+        if "person" in metadata:
+            record["person"] = metadata["person"]
+        if "date_of_birth" in metadata:
+            record["date_of_birth"] = metadata["date_of_birth"]
+        if "expiration_date" in metadata:
+            record["expiration_date"] = metadata["expiration_date"]
+        if "passport_number" in metadata:
+            record["passport_number"] = metadata["passport_number"]
 
     if path is not None:
         record["path"] = path

--- a/tests/test_metadata_generation.py
+++ b/tests/test_metadata_generation.py
@@ -107,3 +107,16 @@ def test_multilanguage_tags_parsing(monkeypatch):
     meta = result["metadata"]
     assert meta["tags_ru"] == ["тег1", "тег2"]
     assert meta["tags_en"] == ["tag1", "tag2"]
+
+
+def test_generate_metadata_parses_mrz():
+    text = (
+        "P<UTOERIKSSON<<ANNA<MARIA<<<<<<<<<<<<<<<<<<<\n"
+        "L898902C<3UTO7408122F1204159ZE184226B<<<<<<<<<10"
+    )
+    result = generate_metadata(text, analyzer=RegexAnalyzer())
+    meta = result["metadata"]
+    assert meta["person"] == "ANNA MARIA ERIKSSON"
+    assert meta["date_of_birth"] == "1974-08-12"
+    assert meta["expiration_date"] == "2012-04-15"
+    assert meta["passport_number"] == "L898902C3"

--- a/tests/test_mrz.py
+++ b/tests/test_mrz.py
@@ -1,0 +1,18 @@
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from file_utils.mrz import parse_mrz
+
+
+def test_parse_mrz_extracts_fields():
+    text = (
+        "P<UTOERIKSSON<<ANNA<MARIA<<<<<<<<<<<<<<<<<<<\n"
+        "L898902C<3UTO7408122F1204159ZE184226B<<<<<<<<<10"
+    )
+    result = parse_mrz(text)
+    assert result["passport_number"] == "L898902C3"
+    assert result["person"] == "ANNA MARIA ERIKSSON"
+    assert result["date_of_birth"] == "1974-08-12"
+    assert result["expiration_date"] == "2012-04-15"

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -67,7 +67,10 @@ def _mock_generate_metadata(text: str, folder_tree=None):
             "category": None,
             "subcategory": None,
             "issuer": None,
-            "person": None,
+            "person": "John Doe",
+            "date_of_birth": "1990-01-02",
+            "expiration_date": "2030-01-02",
+            "passport_number": "X1234567",
             "doc_type": None,
             "date": "2024-01-01",
             "amount": None,
@@ -119,6 +122,9 @@ def test_upload_retrieve_and_download(tmp_path, monkeypatch):
         assert captured["language"] == "deu"
         assert data["prompt"] == "PROMPT"
         assert data["raw_response"] == "{\"date\": \"2024-01-01\"}"
+        assert data["metadata"]["person"] == "John Doe"
+        assert data["metadata"]["date_of_birth"] == "1990-01-02"
+        assert data["metadata"]["expiration_date"] == "2030-01-02"
 
         # Чтение метаданных
         meta = client.get(f"/metadata/{file_id}")
@@ -148,6 +154,11 @@ def test_upload_retrieve_and_download(tmp_path, monkeypatch):
         assert translated.status_code == 200
         assert translated.text == "content-eng"
         assert calls["n"] == 1
+
+        record = server.database.get_file(file_id)
+        assert record["person"] == "John Doe"
+        assert record["date_of_birth"] == "1990-01-02"
+        assert record["expiration_date"] == "2030-01-02"
 
 
 def test_upload_images_returns_sources(tmp_path, monkeypatch):
@@ -281,6 +292,10 @@ def test_details_endpoint_returns_full_record(tmp_path, monkeypatch):
         expected["translated_text"] = None
         expected["translation_lang"] = None
         expected["chat_history"] = []
+        expected["person"] = data["metadata"]["person"]
+        expected["date_of_birth"] = data["metadata"]["date_of_birth"]
+        expected["expiration_date"] = data["metadata"]["expiration_date"]
+        expected["passport_number"] = data["metadata"]["passport_number"]
         details_json_no_emb = details_json.copy()
         details_json_no_emb.pop("embedding", None)
         assert details_json_no_emb == expected


### PR DESCRIPTION
## Описание
- Добавлен модуль `parse_mrz` для извлечения данных из MRZ
- Метаданные дополняются полями `person`, `date_of_birth`, `expiration_date` после OCR
- БД и API обновлены для хранения новых полей
- Добавлены тесты для MRZ и расширены существующие

## Тестирование
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a864e86c548330bc5b43b26cba794e