### PR TITLE
feat(frontend): add image cropping with Cropper.js

### DIFF
--- a/src/web_app/templates/index.html
+++ b/src/web_app/templates/index.html
@@ -4,6 +4,8 @@
     <meta charset="utf-8">
     <title>DocRouter</title>
     <link rel="stylesheet" href="/static/style.css">
+    <link href="https://unpkg.com/cropperjs@1.5.13/dist/cropper.min.css" rel="stylesheet" />
+    <script src="https://unpkg.com/cropperjs@1.5.13/dist/cropper.min.js" defer></script>
     <script src="/static/main.js" defer></script>
 </head>
 <body>
@@ -91,8 +93,8 @@
             <span class="close" data-close="edit-modal">&times;</span>
             <canvas id="edit-canvas"></canvas>
             <div class="modal-buttons">
-                <button id="rotate-btn" type="button">Повернуть</button>
-                <button id="crop-btn" type="button">Обрезать</button>
+                <button id="rotate-left-btn" type="button">Повернуть влево</button>
+                <button id="rotate-right-btn" type="button">Повернуть вправо</button>
                 <button id="save-btn" type="button">Сохранить</button>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- add Cropper.js CDN links and rotate controls to edit modal
- initialize Cropper on the edit canvas and rotate/crop images
- save edited image via `getCroppedCanvas().toBlob` for upload

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab5f004348833098d1547c9635939f