### PR TITLE
feat: async http clients

### DIFF
--- a/src/docrouter.py
+++ b/src/docrouter.py
@@ -5,6 +5,7 @@ import logging
 
 from file_utils import extract_text
 import metadata_generation
+import asyncio
 from file_sorter import place_file
 
 from error_handling import handle_error
@@ -27,7 +28,7 @@ def process_directory(input_dir: str | Path, dest_root: str | Path, dry_run: boo
         logger.info("Processing file %s", path)
         try:
             text = extract_text(path)
-            meta_result = metadata_generation.generate_metadata(text)
+            meta_result = asyncio.run(metadata_generation.generate_metadata(text))
             raw_meta = meta_result["metadata"]
             if isinstance(raw_meta, dict):
                 metadata = raw_meta

--- a/src/file_utils/__init__.py
+++ b/src/file_utils/__init__.py
@@ -6,7 +6,7 @@ import csv
 import logging
 import tempfile
 from PIL import Image, ImageOps
-import requests
+import httpx
 
 from config import (
     OPENROUTER_API_KEY,
@@ -240,7 +240,7 @@ except Exception:  # pragma: no cover - отсутствие плагинов н
     logger.debug("Plugin loading skipped", exc_info=True)
 
 
-def translate_text(text: str, target_lang: str) -> str:
+async def translate_text(text: str, target_lang: str) -> str:
     """Перевести *text* на язык ``target_lang`` с помощью OpenRouter."""
 
     if not OPENROUTER_API_KEY:
@@ -260,7 +260,8 @@ def translate_text(text: str, target_lang: str) -> str:
         "HTTP-Referer": OPENROUTER_SITE_URL or "https://github.com/docrouter",
         "X-Title": OPENROUTER_SITE_NAME or "DocRouter",
     }
-    response = requests.post(api_url, json=payload, headers=headers, timeout=60)
+    async with httpx.AsyncClient(timeout=60) as client:
+        response = await client.post(api_url, json=payload, headers=headers)
     response.raise_for_status()
     content = response.json()["choices"][0]["message"]["content"]
     return content.strip()

--- a/src/web_app/routes/files.py
+++ b/src/web_app/routes/files.py
@@ -42,7 +42,7 @@ async def download_file(file_id: str, lang: str | None = None):
         elif record.translation_lang == lang and record.translated_text:
             text = record.translated_text
         else:
-            text = server.translate_text(extracted, lang)
+            text = await server.translate_text(extracted, lang)
             database.update_file(
                 file_id,
                 translated_text=text,
@@ -84,7 +84,7 @@ async def get_file_details(file_id: str, lang: str | None = None):
         elif record.translation_lang == lang and record.translated_text:
             text = record.translated_text
         else:
-            text = server.translate_text(extracted, lang)
+            text = await server.translate_text(extracted, lang)
             database.update_file(
                 file_id,
                 translated_text=text,

--- a/src/web_app/routes/upload.py
+++ b/src/web_app/routes/upload.py
@@ -37,7 +37,7 @@ async def upload_file(
         lang = language or server.config.tesseract_lang
         text = server.extract_text(temp_path, language=lang)
         folder_tree = get_folder_tree(server.config.output_dir)
-        meta_result = server.metadata_generation.generate_metadata(text, folder_tree=folder_tree)
+        meta_result = await server.metadata_generation.generate_metadata(text, folder_tree=folder_tree)
         raw_meta = meta_result["metadata"]
         if isinstance(raw_meta, dict):
             metadata = Metadata(**raw_meta)
@@ -148,7 +148,7 @@ async def upload_images(
         lang = language or server.config.tesseract_lang
         text = server.extract_text(pdf_path, language=lang)
         folder_tree = get_folder_tree(server.config.output_dir)
-        meta_result = server.metadata_generation.generate_metadata(text, folder_tree=folder_tree)
+        meta_result = await server.metadata_generation.generate_metadata(text, folder_tree=folder_tree)
         raw_meta = meta_result["metadata"]
         if isinstance(raw_meta, dict):
             metadata = Metadata(**raw_meta)

--- a/tests/test_docrouter_recursive.py
+++ b/tests/test_docrouter_recursive.py
@@ -14,7 +14,7 @@ def test_process_directory_preserves_subdirs(tmp_path, monkeypatch):
     file_path = input_dir / "data.txt"
     file_path.write_text("hello", encoding="utf-8")
 
-    def fake_generate(text):
+    async def fake_generate(text):
         return {"prompt": None, "raw_response": None, "metadata": Metadata(date="2024-01-01")}
 
     monkeypatch.setattr(metadata_generation, "generate_metadata", fake_generate)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -27,7 +27,7 @@ def test_process_directory_logs(tmp_path, monkeypatch, caplog):
     file_path = input_dir / "data.txt"
     file_path.write_text("hello", encoding="utf-8")
 
-    def fake_generate(text):
+    async def fake_generate(text):
         return {"prompt": None, "raw_response": None, "metadata": Metadata(date="2024-01-01")}
 
     monkeypatch.setattr(metadata_generation, "generate_metadata", fake_generate)

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -59,7 +59,7 @@ class LiveClient:
         return self.session.delete(self.base_url + path, **kwargs)
 
 
-def _mock_generate_metadata(text: str, folder_tree=None):
+async def _mock_generate_metadata(text: str, folder_tree=None):
     """Детерминированные метаданные для стабильных проверок."""
     meta = Metadata(
         person="John Doe",
@@ -144,7 +144,7 @@ def test_upload_retrieve_and_download(tmp_path, monkeypatch):
         # Перевод и повторное скачивание
         calls = {"n": 0}
 
-        def _mock_translate(text, target_lang):
+        async def _mock_translate(text, target_lang):
             calls["n"] += 1
             return f"{text}-{target_lang}"
 
@@ -405,7 +405,7 @@ def test_upload_pending_then_finalize(tmp_path, monkeypatch):
         with open(path, "r", encoding="utf-8") as f:
             return f.read()
 
-    def _metadata_pending(text: str, folder_tree=None):
+    async def _metadata_pending(text: str, folder_tree=None):
         meta = Metadata(
             category="Финансы",
             subcategory="Банки",


### PR DESCRIPTION
## Summary
- switch metadata generation and translation to async httpx
- await async metadata and translation in upload and file routes
- mark async tests accordingly

## Testing
- `pytest` *(fails: async tests unsupported; pytest-asyncio missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ab76d1cd748330a7226ab84b17d364