### PR TITLE
Добавлена поддержка PNG и TIFF

### DIFF
--- a/src/file_utils/__init__.py
+++ b/src/file_utils/__init__.py
@@ -146,7 +146,7 @@ def extract_text(file_path: Union[str, Path], language: str = "eng") -> str:
     Поддерживаемые форматы:
       - Текстовые: .txt, .md, .pdf, .docx
       - Таблицы: .csv, .xls, .xlsx
-      - Изображения (OCR): .jpg, .jpeg  (через image_ocr.extract_text_image)
+      - Изображения (OCR): .jpg, .jpeg, .png, .tiff (через image_ocr.extract_text_image)
 
     :param file_path: путь к файлу.
     :param language: язык OCR (ISO-коды tesseract, напр. 'eng', 'rus', 'deu').
@@ -159,7 +159,7 @@ def extract_text(file_path: Union[str, Path], language: str = "eng") -> str:
     logger.info("Extracting text from %s", path)
 
     # Ветвь для изображений — нужен отдельный параметр language
-    if ext in {".jpg", ".jpeg"}:
+    if ext in {".jpg", ".jpeg", ".png", ".tiff"}:
         if extract_text_image is None:
             logger.error("OCR module unavailable for %s", path)
             raise RuntimeError("Модуль OCR недоступен: .image_ocr.extract_text_image не найден")

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -4,7 +4,8 @@ import csv
 import importlib.util
 from tempfile import TemporaryDirectory
 import unittest
-from PIL import Image
+import shutil
+from PIL import Image, ImageDraw, ImageFont
 
 sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
 
@@ -96,6 +97,26 @@ class TestExtractText(unittest.TestCase):
         with TemporaryDirectory() as tmp:
             path = _create_file(Path(tmp), ".docx", "hello docx")
             self.assertEqual(extract_text(path).strip(), "hello docx")
+
+    @unittest.skipUnless(shutil.which("tesseract"), "tesseract not installed")
+    def test_png(self):
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "sample.png"
+            image = Image.new("RGB", (100, 50), color="white")
+            draw = ImageDraw.Draw(image)
+            draw.text((10, 10), "PNG", fill="black", font=ImageFont.load_default())
+            image.save(path)
+            self.assertIn("PNG", extract_text(path))
+
+    @unittest.skipUnless(shutil.which("tesseract"), "tesseract not installed")
+    def test_tiff(self):
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "sample.tiff"
+            image = Image.new("RGB", (100, 50), color="white")
+            draw = ImageDraw.Draw(image)
+            draw.text((10, 10), "TIFF", fill="black", font=ImageFont.load_default())
+            image.save(path)
+            self.assertIn("TIFF", extract_text(path))
 
 
 @unittest.skipUnless(has_module("fitz"), "PyMuPDF not installed")


### PR DESCRIPTION
## Summary
- extend `extract_text` to process PNG and TIFF images via OCR
- document new formats and add tests for PNG/TIFF

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab76ded6c88330a247ff750ef69752