### PR TITLE
feat: integrate OpenRouter embeddings

### DIFF
--- a/src/file_utils/embeddings.py
+++ b/src/file_utils/embeddings.py
@@ -2,27 +2,21 @@ from __future__ import annotations
 
 """Простой модуль для получения эмбеддингов и расчёта сходства."""
 
-import hashlib
 import math
 from typing import List
 
+from config import config
+from services import openrouter
 
-def get_embedding(text: str, dimensions: int = 8) -> List[float]:
-    """Вернуть детерминированный вектор для *text*.
 
-    Здесь используется простое хеширование, чтобы избежать внешних зависимостей
-    при тестировании. В реальной системе вместо этого должен вызываться
-    embedding‑API.
-    """
+async def get_embedding(text: str, model: str | None = None) -> List[float]:
+    """Получить эмбеддинг для текста через сервис OpenRouter."""
+
     if not text:
-        return [0.0] * dimensions
-    digest = hashlib.sha256(text.encode("utf-8")).digest()
-    step = len(digest) // dimensions
-    vec = []
-    for i in range(dimensions):
-        chunk = digest[i * step:(i + 1) * step]
-        vec.append(int.from_bytes(chunk, "big") / 2 ** 32)
-    return vec
+        return []
+
+    model_name = model or config.openrouter_model or "text-embedding-3-small"
+    return await openrouter.embed(text, model_name)
 
 
 def cosine_similarity(v1: List[float], v2: List[float]) -> float:

--- a/src/services/openrouter.py
+++ b/src/services/openrouter.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Tuple
 
+import asyncio
+import logging
+
 import httpx
 
 from config import (
@@ -13,6 +16,9 @@ from config import (
     OPENROUTER_SITE_URL,
     OPENROUTER_SITE_NAME,
 )
+
+
+logger = logging.getLogger(__name__)
 
 
 async def chat(messages: List[Dict[str, str]]) -> Tuple[str, int | None, float | None]:
@@ -42,3 +48,46 @@ async def chat(messages: List[Dict[str, str]]) -> Tuple[str, int | None, float |
     tokens = usage.get("total_tokens")
     cost = usage.get("total_cost")
     return reply, tokens, cost
+
+
+async def embed(text: str, model: str) -> List[float]:
+    """Получить эмбеддинг для текста через OpenRouter.
+
+    Делает несколько попыток при временных ошибках и логирует их."""
+
+    if not OPENROUTER_API_KEY:
+        raise RuntimeError("OPENROUTER_API_KEY environment variable required")
+
+    base_url = OPENROUTER_BASE_URL or "https://openrouter.ai/api/v1"
+    api_url = base_url.rstrip("/") + "/embeddings"
+
+    payload: Dict[str, Any] = {"model": model, "input": text}
+    headers = {
+        "Authorization": f"Bearer {OPENROUTER_API_KEY}",
+        "HTTP-Referer": OPENROUTER_SITE_URL or "https://github.com/docrouter",
+        "X-Title": OPENROUTER_SITE_NAME or "DocRouter",
+    }
+
+    async with httpx.AsyncClient(timeout=60) as client:
+        for attempt in range(3):
+            try:
+                response = await client.post(api_url, json=payload, headers=headers)
+                response.raise_for_status()
+                data = response.json()
+                return data["data"][0]["embedding"]
+            except httpx.HTTPStatusError as exc:
+                status = exc.response.status_code
+                if status == 429 and attempt < 2:
+                    wait = 2 ** attempt
+                    logger.warning(
+                        "OpenRouter rate limited (429). Retrying in %s seconds", wait
+                    )
+                    await asyncio.sleep(wait)
+                    continue
+                logger.error("OpenRouter embedding failed: %s", exc)
+                raise
+            except httpx.HTTPError as exc:
+                logger.error("HTTP error during embedding request: %s", exc)
+                raise
+
+    raise RuntimeError("Failed to fetch embedding from OpenRouter")

--- a/src/web_app/routes/files.py
+++ b/src/web_app/routes/files.py
@@ -105,7 +105,7 @@ async def list_files():
 @router.get("/search/semantic")
 async def semantic_search(q: str):
     """Семантический поиск по сохранённым документам."""
-    query_vec = get_embedding(q)
+    query_vec = await get_embedding(q)
     results: list[dict[str, object]] = []
     for rec in database.list_files():
         emb = rec.embedding

--- a/src/web_app/routes/upload.py
+++ b/src/web_app/routes/upload.py
@@ -45,7 +45,7 @@ async def upload_file(
             metadata = raw_meta
         metadata.extracted_text = text
         metadata.language = lang
-        embedding = get_embedding(text)
+        embedding = await get_embedding(text)
 
         meta_dict = metadata.model_dump()
         # Раскладываем файл по директориям без создания недостающих
@@ -156,7 +156,7 @@ async def upload_images(
             metadata = raw_meta
         metadata.extracted_text = text
         metadata.language = lang
-        embedding = get_embedding(text)
+        embedding = await get_embedding(text)
 
         meta_dict = metadata.model_dump()
         dest_path, missing = place_file(

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -1,0 +1,13 @@
+import asyncio
+
+from file_utils.embeddings import get_embedding
+
+
+def test_get_embedding_returns_vector(monkeypatch):
+    async def fake_embed(text: str, model: str):
+        return [0.1] * 8
+
+    monkeypatch.setattr("file_utils.embeddings.openrouter.embed", fake_embed)
+
+    vec = asyncio.run(get_embedding("hello"))
+    assert len(vec) == 8

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import requests
 import uvicorn
 from PIL import Image
+import pytest
 
 # Добавляем путь к src ДО импорта сервера
 sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
@@ -20,6 +21,14 @@ from web_app import server  # noqa: E402
 from models import Metadata  # noqa: E402
 
 app = server.app
+
+
+@pytest.fixture(autouse=True)
+def _mock_embeddings(monkeypatch):
+    async def fake_embed(text: str, model: str):
+        return [0.1] * 8
+
+    monkeypatch.setattr("file_utils.embeddings.openrouter.embed", fake_embed)
 
 
 class LiveClient:


### PR DESCRIPTION
## Summary
- add async `openrouter.embed` with retry and logging
- use OpenRouter embeddings via config
- adjust routes and tests to async embeddings

## Testing
- `pip install pytest-asyncio` *(fails: Could not find a version that satisfies the requirement)*
- `pytest -q` *(fails: async def functions are not natively supported)*
- `pytest tests/test_embeddings.py tests/test_semantic_search.py tests/test_web_app.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b43249480483308b5f11d1e0e959dd