### PR TITLE
Add viewport meta tag to improve responsive design

### DIFF
--- a/src/web_app/templates/index.html
+++ b/src/web_app/templates/index.html
@@ -2,6 +2,7 @@
 <html lang="ru">
 <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>DocRouter</title>
     <link rel="stylesheet" href="/static/style.css">
     <link href="https://unpkg.com/cropperjs@1.5.13/dist/cropper.min.css" rel="stylesheet" />


### PR DESCRIPTION
## Summary
- enhance responsive layout by adding a viewport meta tag to the main template

## Testing
- `pytest`
- `npm run build`
- `npx -p puppeteer node - <<'NODE' ...` *(failed: 403 Forbidden to fetch puppeteer)*

------
https://chatgpt.com/codex/tasks/task_e_68b44b01b9c0833098ee512ff629ea14