### PR TITLE
feat: fallback to english when ocr language missing

### DIFF
--- a/tests/test_image_ocr.py
+++ b/tests/test_image_ocr.py
@@ -15,3 +15,15 @@ def test_extract_text_from_image(tmp_path):
 
     text = extract_text(image_path)
     assert 'OCR' in text
+
+
+@pytest.mark.skipif(shutil.which("tesseract") is None, reason="tesseract not installed")
+def test_extract_text_from_image_fallback_language(tmp_path):
+    image = Image.new('RGB', (100, 50), color='white')
+    draw = ImageDraw.Draw(image)
+    draw.text((10, 10), 'OCR', fill='black', font=ImageFont.load_default())
+    image_path = tmp_path / 'sample.jpg'
+    image.save(image_path)
+
+    text = extract_text(image_path, language='xyz')
+    assert 'OCR' in text


### PR DESCRIPTION
## Summary
- handle missing Tesseract language files by falling back to English
- add test covering OCR language fallback

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b44f3d1c78833080f463e38b129fac