### PR TITLE
feat: make OCR pre-processing configurable

### DIFF
--- a/tests/test_ocr_pipeline.py
+++ b/tests/test_ocr_pipeline.py
@@ -1,0 +1,14 @@
+import pytest
+
+np = pytest.importorskip("numpy")
+
+from ocr_pipeline import remove_noise
+
+
+def test_remove_noise_ksize_validation():
+    image = np.zeros((5, 5), dtype=np.uint8)
+    with pytest.raises(ValueError):
+        remove_noise(image, ksize=2)
+    with pytest.raises(ValueError):
+        remove_noise(image, ksize=1)
+    assert remove_noise(image, ksize=3).shape == image.shape


### PR DESCRIPTION
## Summary
- allow tuning contrast and brightness in `increase_contrast`
- validate median blur kernel in `remove_noise`
- expose OCR pre-processing parameters through CLI and pipeline

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b450be71848330b578dc335e5efdbe