### PR TITLE
Validate OCR inputs

### DIFF
--- a/src/ocr_pipeline.py
+++ b/src/ocr_pipeline.py
@@ -80,6 +80,8 @@ def resize_to_dpi(image: np.ndarray, dpi: int = 300) -> np.ndarray:
     :param dpi: Target DPI value.
     :return: Resized image.
     """
+    if dpi <= 0:
+        raise ValueError("dpi must be > 0")
     pil_img = Image.fromarray(image)
     orig_dpi = pil_img.info.get("dpi", (72, 72))[0] or 72
     scale = dpi / orig_dpi
@@ -121,10 +123,25 @@ def run_ocr(
     :param beta: Brightness control passed to :func:`increase_contrast`.
     :param ksize: Kernel size for :func:`remove_noise`.
     :return: Recognized text as a string.
+    :raises FileNotFoundError: If the image file does not exist.
+    :raises ValueError: If the file has an unsupported extension or cannot be loaded.
     """
+    path = Path(path)
+    if not path.exists():
+        raise FileNotFoundError(f"Image not found: {path}")
+    if path.suffix.lower() not in {
+        ".png",
+        ".jpg",
+        ".jpeg",
+        ".tif",
+        ".tiff",
+        ".bmp",
+        ".gif",
+    }:
+        raise ValueError(f"Unsupported image extension: {path.suffix}")
     image = cv2.imread(str(path))
     if image is None:
-        raise FileNotFoundError(f"Image not found: {path}")
+        raise ValueError(f"Unable to load image: {path}")
     image = resize_to_dpi(image, dpi)
     image = increase_contrast(image, alpha=alpha, beta=beta)
     image = remove_noise(image, ksize=ksize)

--- a/tests/test_ocr_pipeline.py
+++ b/tests/test_ocr_pipeline.py
@@ -2,7 +2,7 @@ import pytest
 
 np = pytest.importorskip("numpy")
 
-from ocr_pipeline import remove_noise
+from ocr_pipeline import remove_noise, resize_to_dpi, run_ocr
 
 
 def test_remove_noise_ksize_validation():
@@ -12,3 +12,28 @@ def test_remove_noise_ksize_validation():
     with pytest.raises(ValueError):
         remove_noise(image, ksize=1)
     assert remove_noise(image, ksize=3).shape == image.shape
+
+
+def test_resize_to_dpi_dpi_validation():
+    image = np.zeros((5, 5), dtype=np.uint8)
+    with pytest.raises(ValueError):
+        resize_to_dpi(image, dpi=0)
+
+
+def test_run_ocr_missing_file():
+    with pytest.raises(FileNotFoundError):
+        run_ocr("missing.png")
+
+
+def test_run_ocr_unsupported_extension(tmp_path):
+    file_path = tmp_path / "file.txt"
+    file_path.write_text("test")
+    with pytest.raises(ValueError):
+        run_ocr(file_path)
+
+
+def test_run_ocr_unreadable_image(tmp_path):
+    file_path = tmp_path / "broken.png"
+    file_path.write_text("not an image")
+    with pytest.raises(ValueError):
+        run_ocr(file_path)


### PR DESCRIPTION
## Summary
- validate DPI argument in `resize_to_dpi`
- add file existence, extension, and load checks to `run_ocr`
- cover edge cases with tests

## Testing
- `pytest`
- `pytest tests/test_ocr_pipeline.py -q` *(fails: skipped: 1)*
- `pip install numpy` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b451c7d16083309e7419671ba40ca9