### PR TITLE
Handle OpenRouter embedding failures

### DIFF
--- a/src/metadata_generation.py
+++ b/src/metadata_generation.py
@@ -25,6 +25,7 @@ from config import (
     OPENROUTER_SITE_URL,
 )
 
+from services.openrouter import OpenRouterError
 from file_utils.mrz import parse_mrz
 
 
@@ -47,10 +48,6 @@ def get_analyzer(name: str) -> type["MetadataAnalyzer"]:
     """Получить класс анализатора по имени."""
 
     return _ANALYZER_REGISTRY[name]
-
-
-class OpenRouterError(RuntimeError):
-    """Исключение при обращении к OpenRouter."""
 
 
 __all__ = [

--- a/src/web_app/routes/chat.py
+++ b/src/web_app/routes/chat.py
@@ -5,6 +5,7 @@ from fastapi import APIRouter, HTTPException, Body
 
 from .. import db as database
 from services import openrouter
+from services.openrouter import OpenRouterError
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -25,6 +26,9 @@ async def chat(file_id: str, message: str = Body(..., embed=True)):
     ]
     try:
         reply, tokens, cost = await openrouter.chat(messages)
+    except OpenRouterError as exc:
+        logger.exception("OpenRouter chat failed")
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
     except Exception as exc:  # pragma: no cover - сеть может быть недоступна
         logger.exception("OpenRouter chat failed")
         raise HTTPException(status_code=500, detail=str(exc)) from exc

--- a/src/web_app/routes/files.py
+++ b/src/web_app/routes/files.py
@@ -10,6 +10,7 @@ from fastapi import APIRouter, HTTPException, Body
 from fastapi.responses import FileResponse, PlainTextResponse
 
 from file_utils.embeddings import get_embedding, cosine_similarity
+from services.openrouter import OpenRouterError
 from file_sorter import place_file
 from models import Metadata, FileRecord
 from .. import db as database, server
@@ -105,7 +106,10 @@ async def list_files():
 @router.get("/search/semantic")
 async def semantic_search(q: str):
     """Семантический поиск по сохранённым документам."""
-    query_vec = await get_embedding(q)
+    try:
+        query_vec = await get_embedding(q)
+    except OpenRouterError as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
     results: list[dict[str, object]] = []
     for rec in database.list_files():
         emb = rec.embedding

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -1,6 +1,9 @@
 import asyncio
 
+import pytest
+
 from file_utils.embeddings import get_embedding
+from services.openrouter import embed, OpenRouterError
 
 
 def test_get_embedding_returns_vector(monkeypatch):
@@ -11,3 +14,34 @@ def test_get_embedding_returns_vector(monkeypatch):
 
     vec = asyncio.run(get_embedding("hello"))
     assert len(vec) == 8
+
+
+def test_embed_non_json_response(monkeypatch):
+    class DummyResponse:
+        status_code = 200
+        text = "<html></html>"
+
+        def raise_for_status(self) -> None:
+            pass
+
+        def json(self):  # type: ignore[override]
+            raise ValueError("no json")
+
+    class DummyClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def post(self, *args, **kwargs):
+            return DummyResponse()
+
+    monkeypatch.setattr("services.openrouter.OPENROUTER_API_KEY", "test")
+    monkeypatch.setattr("services.openrouter.httpx.AsyncClient", DummyClient)
+
+    with pytest.raises(OpenRouterError):
+        asyncio.run(embed("text", "model"))

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -19,6 +19,7 @@ os.environ["DB_URL"] = ":memory:"             # in-memory БД для тесто
 # Импортируем сервер
 from web_app import server  # noqa: E402
 from models import Metadata  # noqa: E402
+from services.openrouter import OpenRouterError
 
 app = server.app
 
@@ -314,7 +315,21 @@ def test_details_endpoint_returns_full_record(tmp_path, monkeypatch):
         expected["created_path"] = None
         details_json_no_emb = details_json.copy()
         details_json_no_emb.pop("embedding", None)
-        assert details_json_no_emb == expected
+    assert details_json_no_emb == expected
+
+
+def test_upload_embedding_failure_returns_502(tmp_path, monkeypatch):
+    monkeypatch.setattr(server.metadata_generation, "generate_metadata", _mock_generate_metadata)
+    server.config.output_dir = str(tmp_path)
+
+    async def failing_embed(text: str, model: str):
+        raise OpenRouterError("boom")
+
+    monkeypatch.setattr("file_utils.embeddings.openrouter.embed", failing_embed)
+
+    with LiveClient(app) as client:
+        resp = client.post("/upload", files={"file": ("example.txt", b"content")})
+        assert resp.status_code == 502
 
 
 def test_download_file_not_found_returns_404(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- add `OpenRouterError` and raise it from OpenRouter chat/embed wrappers
- return HTTP 502 when embeddings fail in upload, image upload, semantic search and chat routes
- cover non-JSON and upload failure scenarios with tests

## Testing
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68b4558abc5c8330abd98091ec5588ed