### PR TITLE
Validate archive root and normalize language codes

### DIFF
--- a/src/file_sorter.py
+++ b/src/file_sorter.py
@@ -98,6 +98,13 @@ def place_file(
     """
     src = Path(src_path)
     base_dir = Path(dest_root)
+    if base_dir.exists():
+        if not base_dir.is_dir():
+            raise NotADirectoryError(
+                f"Destination root exists and is not a directory: {base_dir}"
+            )
+    else:  # Создаём корень архива, если его нет
+        base_dir.mkdir(parents=True, exist_ok=True)
 
     ext = src.suffix
     name = metadata.get("suggested_name") or src.stem
@@ -148,7 +155,12 @@ def place_file(
 
     # Создаём недостающие каталоги только при подтверждении
     if missing and needs_new_folder and confirm_callback(missing):
-        dest_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            dest_dir.mkdir(parents=True, exist_ok=True)
+        except FileExistsError as exc:
+            raise NotADirectoryError(
+                f"Cannot create directory '{exc.filename}'"
+            ) from exc
         confirmed = True
         missing = []
 

--- a/src/web_app/templates/index.html
+++ b/src/web_app/templates/index.html
@@ -18,9 +18,9 @@
             <input type="file" name="file" />
             <label for="language">Язык документа:</label>
             <select name="language" id="language">
-                <option value="eng">English</option>
-                <option value="rus" selected>Русский</option>
-                <option value="deu">Deutsch</option>
+                <option value="en">English</option>
+                <option value="ru" selected>Русский</option>
+                <option value="de">Deutsch</option>
             </select>
             <input type="submit" value="Upload" />
         </form>
@@ -46,9 +46,9 @@
         <label for="display-lang">Язык отображения:</label>
         <select id="display-lang">
             <option value="">Оригинал</option>
-            <option value="eng">English</option>
-            <option value="rus">Русский</option>
-            <option value="deu">Deutsch</option>
+            <option value="en">English</option>
+            <option value="ru">Русский</option>
+            <option value="de">Deutsch</option>
         </select>
 
         <label for="tag-language">Язык тегов:</label>

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -105,7 +105,7 @@ def test_upload_retrieve_and_download(tmp_path, monkeypatch):
         # Загрузка
         resp = client.post(
             "/upload",
-            data={"language": "deu"},
+            data={"language": "de"},
             files={"file": ("example.txt", b"content")},
         )
         assert resp.status_code == 200
@@ -125,7 +125,7 @@ def test_upload_retrieve_and_download(tmp_path, monkeypatch):
         assert data["status"] in {"dry_run", "processed"}
         assert data["missing"] == []
         assert data["metadata"]["extracted_text"].strip() == "content"
-        assert data["metadata"]["language"] == "deu"
+        assert data["metadata"]["language"] == "de"
         assert captured["language"] == "deu"
         assert data["prompt"] == "PROMPT"
         assert data["raw_response"] == "{\"date\": \"2024-01-01\"}"
@@ -152,14 +152,14 @@ def test_upload_retrieve_and_download(tmp_path, monkeypatch):
 
         monkeypatch.setattr(server, "translate_text", _mock_translate)
 
-        details = client.get(f"/files/{file_id}/details?lang=eng")
+        details = client.get(f"/files/{file_id}/details?lang=en")
         assert details.status_code == 200
-        assert details.json()["translated_text"] == "content-eng"
-        assert details.json()["translation_lang"] == "eng"
+        assert details.json()["translated_text"] == "content-en"
+        assert details.json()["translation_lang"] == "en"
 
-        translated = client.get(f"/download/{file_id}?lang=eng")
+        translated = client.get(f"/download/{file_id}?lang=en")
         assert translated.status_code == 200
-        assert translated.text == "content-eng"
+        assert translated.text == "content-en"
         assert calls["n"] == 1
 
         record = server.database.get_file(file_id)
@@ -195,13 +195,13 @@ def test_upload_images_returns_sources(tmp_path, monkeypatch):
         ]
         resp = client.post(
             "/upload/images",
-            data={"language": "deu"},
+            data={"language": "de"},
             files=files,
         )
         assert resp.status_code == 200
         data = resp.json()
         assert data["sources"] == ["a.jpg", "b.jpg"]
-        assert data["metadata"]["language"] == "deu"
+        assert data["metadata"]["language"] == "de"
         assert captured["language"] == "deu"
         file_id = data["id"]
 
@@ -244,7 +244,7 @@ def test_upload_images_download_and_metadata(tmp_path, monkeypatch):
         ]
         resp = client.post(
             "/upload/images",
-            data={"language": "deu"},
+            data={"language": "de"},
             files=files,
         )
         assert resp.status_code == 200
@@ -281,7 +281,7 @@ def test_details_endpoint_returns_full_record(tmp_path, monkeypatch):
     with LiveClient(app) as client:
         resp = client.post(
             "/upload",
-            data={"language": "deu"},
+            data={"language": "de"},
             files={"file": ("example.txt", b"content")},
         )
         assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- Avoid crashes when archive root path collides with a file
- Accept ISO-639-1 language codes and map them for Tesseract
- Update frontend language selectors to use two-letter codes

## Testing
- `npm run build`
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b45ca462408330902afbeebe1f8dc9