### PR TITLE
Исправление значений по умолчанию для списков в моделях

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any, List, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class Metadata(BaseModel):
@@ -16,9 +16,9 @@ class Metadata(BaseModel):
     expiration_date: Optional[str] = None
     passport_number: Optional[str] = None
     amount: Optional[str] = None
-    tags: List[str] = []
-    tags_ru: List[str] = []
-    tags_en: List[str] = []
+    tags: List[str] = Field(default_factory=list)
+    tags_ru: List[str] = Field(default_factory=list)
+    tags_en: List[str] = Field(default_factory=list)
     suggested_filename: Optional[str] = None
     description: Optional[str] = None
     needs_new_folder: bool = False
@@ -33,8 +33,8 @@ class FileRecord(BaseModel):
     id: str
     filename: str
     metadata: Metadata
-    tags_ru: List[str] = []
-    tags_en: List[str] = []
+    tags_ru: List[str] = Field(default_factory=list)
+    tags_en: List[str] = Field(default_factory=list)
     person: Optional[str] = None
     date_of_birth: Optional[str] = None
     expiration_date: Optional[str] = None
@@ -43,10 +43,10 @@ class FileRecord(BaseModel):
     status: str
     prompt: Any | None = None
     raw_response: Any | None = None
-    missing: List[str] = []
+    missing: List[str] = Field(default_factory=list)
     translated_text: Optional[str] = None
     translation_lang: Optional[str] = None
-    chat_history: List[dict[str, Any]] = []
+    chat_history: List[dict[str, Any]] = Field(default_factory=list)
     sources: Optional[List[str]] = None
     suggested_path: Optional[str] = None
     created_path: Optional[str] = None
@@ -58,10 +58,10 @@ class UploadResponse(BaseModel):
     status: str
     filename: Optional[str] = None
     metadata: Optional[Metadata] = None
-    tags_ru: List[str] = []
-    tags_en: List[str] = []
+    tags_ru: List[str] = Field(default_factory=list)
+    tags_en: List[str] = Field(default_factory=list)
     path: Optional[str] = None
-    missing: List[str] = []
+    missing: List[str] = Field(default_factory=list)
     prompt: Any | None = None
     raw_response: Any | None = None
     sources: Optional[List[str]] = None

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,32 @@
+import pytest
+
+from models import Metadata, FileRecord, UploadResponse
+
+
+def test_metadata_lists_are_independent():
+    m1 = Metadata()
+    m2 = Metadata()
+    assert m1.tags == []
+    assert m2.tags == []
+    assert m1.tags is not m2.tags
+    assert m1.tags_ru is not m2.tags_ru
+    assert m1.tags_en is not m2.tags_en
+
+
+def test_file_record_lists_are_independent():
+    fr1 = FileRecord(id="1", filename="a.txt", metadata=Metadata(), path="p1", status="s1")
+    fr2 = FileRecord(id="2", filename="b.txt", metadata=Metadata(), path="p2", status="s2")
+    assert fr1.tags_ru == [] and fr2.tags_ru == []
+    assert fr1.tags_ru is not fr2.tags_ru
+    assert fr1.tags_en is not fr2.tags_en
+    assert fr1.missing is not fr2.missing
+    assert fr1.chat_history is not fr2.chat_history
+
+
+def test_upload_response_lists_are_independent():
+    u1 = UploadResponse(id="1", status="ok")
+    u2 = UploadResponse(id="2", status="ok")
+    assert u1.tags_ru == [] and u2.tags_ru == []
+    assert u1.tags_ru is not u2.tags_ru
+    assert u1.tags_en is not u2.tags_en
+    assert u1.missing is not u2.missing


### PR DESCRIPTION
## Summary
- Использованы `Field(default_factory=list)` для всех списков в моделях
- Добавлены тесты, проверяющие независимость списков по умолчанию

## Testing
- `pytest tests/test_models.py tests/test_metadata_generation.py`

------
https://chatgpt.com/codex/tasks/task_e_68b45fef065883309cc56d8c230e1134