### PR TITLE
Использовать OpenRouterError при отсутствии API-ключа

### DIFF
--- a/src/services/openrouter.py
+++ b/src/services/openrouter.py
@@ -27,7 +27,7 @@ async def chat(messages: List[Dict[str, str]]) -> Tuple[str, int | None, float |
     """Отправить запрос в OpenRouter и вернуть ответ, количество токенов и стоимость."""
 
     if not OPENROUTER_API_KEY:
-        raise RuntimeError("OPENROUTER_API_KEY environment variable required")
+        raise OpenRouterError("OPENROUTER_API_KEY environment variable required")
 
     model = OPENROUTER_MODEL or "openai/chatgpt-4o-mini"
     base_url = OPENROUTER_BASE_URL or "https://openrouter.ai/api/v1"

--- a/tests/test_metadata_generation.py
+++ b/tests/test_metadata_generation.py
@@ -4,11 +4,8 @@ from typing import Any, Dict
 
 import pytest
 
-from metadata_generation import (
-    generate_metadata,
-    OpenRouterError,
-    MetadataAnalyzer,
-)
+from metadata_generation import generate_metadata, MetadataAnalyzer
+from services.openrouter import OpenRouterError
 from models import Metadata
 
 

--- a/tests/test_openrouter.py
+++ b/tests/test_openrouter.py
@@ -1,0 +1,10 @@
+import asyncio
+import pytest
+from services import openrouter
+
+
+def test_chat_without_api_key(monkeypatch):
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setattr(openrouter, "OPENROUTER_API_KEY", "")
+    with pytest.raises(openrouter.OpenRouterError):
+        asyncio.run(openrouter.chat([{"role": "user", "content": "hi"}]))


### PR DESCRIPTION
## Summary
- поднимаем OpenRouterError вместо RuntimeError, если не задан OPENROUTER_API_KEY
- обновляем тесты и добавляем проверку для openrouter.chat

## Testing
- `pytest tests/test_openrouter.py tests/test_metadata_generation.py`

------
https://chatgpt.com/codex/tasks/task_e_68b45ff59c9c8330bc9889bee68e9942