### PR TITLE
Перевод process_directory на asyncio

### DIFF
--- a/tests/test_docrouter_recursive.py
+++ b/tests/test_docrouter_recursive.py
@@ -1,5 +1,6 @@
 import sys
 from pathlib import Path
+import asyncio
 
 sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
 
@@ -20,7 +21,7 @@ def test_process_directory_preserves_subdirs(tmp_path, monkeypatch):
     monkeypatch.setattr(metadata_generation, "generate_metadata", fake_generate)
 
     dest_root = tmp_path / "Archive"
-    process_directory(tmp_path / "input", dest_root)
+    asyncio.run(process_directory(tmp_path / "input", dest_root))
 
     expected = dest_root / "sub1" / "sub2" / "2024-01-01__data.txt"
     assert expected.exists()

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -2,6 +2,7 @@ import json
 import os
 import sys
 from pathlib import Path
+import asyncio
 
 import pytest
 
@@ -22,7 +23,7 @@ def test_parse_error_moves_file_and_creates_json(tmp_path):
     cwd = os.getcwd()
     os.chdir(tmp_path)
     try:
-        process_directory(input_dir, dest_root, dry_run=True)
+        asyncio.run(process_directory(input_dir, dest_root, dry_run=True))
     finally:
         os.chdir(cwd)
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,6 +1,7 @@
 import logging
 import sys
 from pathlib import Path
+import asyncio
 
 import pytest
 
@@ -35,7 +36,7 @@ def test_process_directory_logs(tmp_path, monkeypatch, caplog):
     dest_root = tmp_path / "Archive"
 
     with caplog.at_level(logging.INFO):
-        process_directory(input_dir, dest_root)
+        asyncio.run(process_directory(input_dir, dest_root))
 
     assert f"Processing directory {input_dir}" in caplog.text
     assert f"Processing file {file_path}" in caplog.text


### PR DESCRIPTION
## Summary
- перевёл `process_directory` на асинхронное выполнение и параллельную генерацию метаданных
- адаптировал тесты к асинхронному API

## Testing
- `pytest` *(ошибка: ImportError: libGL.so.1: cannot open shared object file)*
- `pytest tests/test_docrouter_recursive.py tests/test_error_handling.py tests/test_logging.py`


------
https://chatgpt.com/codex/tasks/task_e_68b45fff134c833084876fcf144d8a8b