### PR TITLE
feat: handle unsupported file types via custom exception

### DIFF
--- a/src/web_app/routes/upload.py
+++ b/src/web_app/routes/upload.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from fastapi import APIRouter, UploadFile, File, HTTPException, Form
 
 from file_sorter import place_file, get_folder_tree
+from file_utils import UnsupportedFileType
 from models import Metadata, UploadResponse
 from services.openrouter import OpenRouterError
 from .. import db as database, server
@@ -77,6 +78,9 @@ async def upload_file(
 
     except HTTPException:
         raise
+    except UnsupportedFileType as exc:
+        logger.exception("Upload/processing failed for %s", filename)
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     except ValueError as exc:
         logger.exception("Upload/processing failed for %s", filename)
         raise HTTPException(status_code=400, detail=str(exc)) from exc
@@ -201,6 +205,9 @@ async def upload_images(
         metadata = Metadata(**meta_dict)
     except HTTPException:
         raise
+    except UnsupportedFileType as exc:
+        logger.exception("Upload/processing failed for images")
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     except Exception as exc:  # pragma: no cover
         logger.exception("Upload/processing failed for images")
         raise HTTPException(status_code=500, detail=str(exc)) from exc

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -6,7 +6,7 @@ import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
 
-from file_utils import extract_text
+from file_utils import extract_text, UnsupportedFileType
 from docrouter import process_directory
 import metadata_generation
 from models import Metadata
@@ -16,7 +16,7 @@ def test_extract_text_logs_error_for_unknown_extension(tmp_path, caplog):
     file_path = tmp_path / "file.xyz"
     file_path.write_text("data", encoding="utf-8")
     with caplog.at_level(logging.ERROR):
-        with pytest.raises(ValueError):
+        with pytest.raises(UnsupportedFileType):
             extract_text(file_path)
     assert "Unsupported/unknown file extension" in caplog.text
 

--- a/tests/test_ocr_pipeline.py
+++ b/tests/test_ocr_pipeline.py
@@ -1,6 +1,7 @@
 import pytest
 
 np = pytest.importorskip("numpy")
+pytest.importorskip("cv2")
 
 from ocr_pipeline import remove_noise, resize_to_dpi, run_ocr
 


### PR DESCRIPTION
## Summary
- add UnsupportedFileType exception for file parsing
- convert unsupported file errors to HTTP 400 in upload routes
- skip OCR pipeline tests when OpenCV is unavailable

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b45ffb9274833095eec9df9b2d9c45