### PR TITLE
feat: add person directory to file sorting

### DIFF
--- a/src/file_sorter.py
+++ b/src/file_sorter.py
@@ -74,7 +74,7 @@ def place_file(
 ) -> Tuple[Path, List[str], bool]:
     """Переместить файл в структуру папок на основе *metadata*.
 
-    Структура: ``<dest_root>/<category>/<subcategory>/<issuer>/<DATE>__<NAME>.<ext>``.
+    Структура: ``<dest_root>/<person>/<category>/<subcategory>/<issuer>/<DATE>__<NAME>.<ext>``.
     Рядом с файлом сохраняется ``.json`` с теми же метаданными.
 
     Возвращает кортеж ``(dest_file, missing, confirmed)``, где:
@@ -88,8 +88,8 @@ def place_file(
         ``confirm_callback``.
 
     :param src_path: путь к исходному файлу.
-    :param metadata: словарь с ключами: ``category``, ``subcategory``, ``issuer``,
-                     ``date`` (YYYY-MM-DD), ``suggested_name``.
+    :param metadata: словарь с ключами: ``person``, ``category``, ``subcategory``,
+                     ``issuer``, ``date`` (YYYY-MM-DD), ``suggested_name``.
     :param dest_root: корень архива.
     :param dry_run: «сухой прогон» без изменений на диске.
     :param needs_new_folder: требуется ли создание новой директории.
@@ -119,6 +119,12 @@ def place_file(
 
     dest_dir = base_dir
     missing: List[str] = []
+
+    person = metadata.get("person") or "Shared"
+    metadata["person"] = person
+    dest_dir /= str(person)
+    if not dest_dir.exists():
+        missing.append(str(dest_dir.relative_to(base_dir)))
 
     for key in ("category", "subcategory", "issuer"):
         value = metadata.get(key)

--- a/tests/test_docrouter_recursive.py
+++ b/tests/test_docrouter_recursive.py
@@ -23,6 +23,6 @@ def test_process_directory_preserves_subdirs(tmp_path, monkeypatch):
     dest_root = tmp_path / "Archive"
     asyncio.run(process_directory(tmp_path / "input", dest_root))
 
-    expected = dest_root / "sub1" / "sub2" / "2024-01-01__data.txt"
+    expected = dest_root / "sub1" / "sub2" / "Shared" / "2024-01-01__data.txt"
     assert expected.exists()
     assert not file_path.exists()

--- a/tests/test_file_sorter.py
+++ b/tests/test_file_sorter.py
@@ -27,12 +27,32 @@ def test_place_file_path_and_name(tmp_path):
     # dry_run: ничего не создаётся, но пути и missing рассчитываются
     dest, missing, _ = place_file(src, sample_metadata(), dest_root, dry_run=True)
 
-    expected = dest_root / "Финансы" / "Банки" / "Sparkasse" / "2023-10-12__Kreditvertrag.pdf"
+    expected = dest_root / "Shared" / "Финансы" / "Банки" / "Sparkasse" / "2023-10-12__Kreditvertrag.pdf"
     assert dest == expected
     assert missing == [
-        "Финансы",
-        "Финансы/Банки",
-        "Финансы/Банки/Sparkasse",
+        "Shared",
+        "Shared/Финансы",
+        "Shared/Финансы/Банки",
+        "Shared/Финансы/Банки/Sparkasse",
+    ]
+
+
+def test_place_file_uses_person_from_metadata(tmp_path):
+    src = tmp_path / "input.pdf"
+    src.write_text("data")
+
+    dest_root = tmp_path / "Archive"
+    metadata = sample_metadata()
+    metadata["person"] = "Alice"
+    dest, missing, _ = place_file(src, metadata, dest_root, dry_run=True)
+
+    expected = dest_root / "Alice" / "Финансы" / "Банки" / "Sparkasse" / "2023-10-12__Kreditvertrag.pdf"
+    assert dest == expected
+    assert missing == [
+        "Alice",
+        "Alice/Финансы",
+        "Alice/Финансы/Банки",
+        "Alice/Финансы/Банки/Sparkasse",
     ]
 
 
@@ -52,6 +72,8 @@ def test_place_file_moves_and_creates_json(tmp_path):
     )
 
     json_path = dest.with_suffix(dest.suffix + ".json")
+    expected = dest_root / "Shared" / "Финансы" / "Банки" / "Sparkasse" / "2023-10-12__Kreditvertrag.pdf"
+    assert dest == expected
     assert dest.exists()
     assert json_path.exists()
     assert missing == []
@@ -119,10 +141,13 @@ def test_place_file_returns_missing_dirs_and_does_not_move_when_needs_new_folder
         needs_new_folder=False,
     )
 
+    expected = dest_root / "Shared" / "Финансы" / "Банки" / "Sparkasse" / "2023-10-12__Kreditvertrag.pdf"
+    assert dest == expected
     assert missing == [
-        "Финансы",
-        "Финансы/Банки",
-        "Финансы/Банки/Sparkasse",
+        "Shared",
+        "Shared/Финансы",
+        "Shared/Финансы/Банки",
+        "Shared/Финансы/Банки/Sparkasse",
     ]
     # файл не должен быть перемещён
     assert not dest.exists()
@@ -158,7 +183,9 @@ def test_place_file_creates_dirs_on_confirmation(tmp_path):
         confirm_callback=lambda _: True,
     )
 
+    expected = dest_root / "Shared" / "Финансы" / "Банки" / "Sparkasse" / "2023-10-12__Kreditvertrag.pdf"
     assert confirmed is True
     assert missing == []
+    assert dest == expected
     assert dest.exists()
     assert dest.parent.exists()


### PR DESCRIPTION
## Summary
- handle optional `person` metadata with default `Shared`
- verify person directory in file sorting tests
- update recursive docrouter test for new person folder

## Testing
- `pytest tests/test_file_sorter.py tests/test_docrouter_recursive.py`

------
https://chatgpt.com/codex/tasks/task_e_68b46126491c8330b3bacd70863beb29