### PR TITLE
Generate suggested_name from suggested_filename

### DIFF
--- a/src/metadata_generation.py
+++ b/src/metadata_generation.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import json
 import logging
 from abc import ABC, abstractmethod
+from pathlib import Path
 from typing import Any, Dict, Optional, Callable
 
 import httpx
@@ -193,6 +194,11 @@ async def generate_metadata(
         "needs_new_folder": False,
     }
     defaults.update(metadata or {})
+
+    suggested_filename = defaults.get("suggested_filename")
+    if suggested_filename:
+        defaults["suggested_name"] = Path(suggested_filename).stem
+
     mrz_info = parse_mrz(text)
     if mrz_info:
         if defaults.get("person") in (None, "") and mrz_info.get("person"):

--- a/src/models.py
+++ b/src/models.py
@@ -20,11 +20,11 @@ class Metadata(BaseModel):
     tags_ru: List[str] = Field(default_factory=list)
     tags_en: List[str] = Field(default_factory=list)
     suggested_filename: Optional[str] = None
+    suggested_name: Optional[str] = None
     description: Optional[str] = None
     needs_new_folder: bool = False
     extracted_text: Optional[str] = None
     language: Optional[str] = None
-    suggested_name: Optional[str] = None
     suggested_name_translit: Optional[str] = None
     new_name_translit: Optional[str] = None
 

--- a/tests/test_file_sorter.py
+++ b/tests/test_file_sorter.py
@@ -16,6 +16,7 @@ def sample_metadata():
         "issuer": "Sparkasse",
         "date": "2023-10-12",
         "suggested_name": "Kreditvertrag",
+        "suggested_filename": "Kreditvertrag.pdf",
     }
 
 
@@ -34,6 +35,18 @@ def test_place_file_path_and_name(tmp_path):
         "Финансы/Банки",
         "Финансы/Банки/Sparkasse",
     ]
+
+
+def test_place_file_prefers_suggested_name(tmp_path):
+    src = tmp_path / "file.pdf"
+    src.write_text("data")
+
+    dest_root = tmp_path / "Archive"
+    metadata = sample_metadata()
+    metadata["suggested_filename"] = "other.pdf"
+
+    dest, _, _ = place_file(src, metadata, dest_root, dry_run=True)
+    assert dest.name == "2023-10-12__Kreditvertrag.pdf"
 
 
 def test_place_file_moves_and_creates_json(tmp_path):

--- a/tests/test_metadata_generation.py
+++ b/tests/test_metadata_generation.py
@@ -135,3 +135,23 @@ def test_generate_metadata_parses_mrz():
     assert meta.date_of_birth == "1974-08-12"
     assert meta.expiration_date == "2012-04-15"
     assert meta.passport_number == "L898902C3"
+
+
+class DummyFilenameAnalyzer(MetadataAnalyzer):
+    async def analyze(
+        self, text: str, folder_tree: Dict[str, Any] | None = None
+    ) -> Dict[str, Any]:
+        return {
+            "prompt": None,
+            "raw_response": None,
+            "metadata": {"suggested_filename": "invoice.pdf"},
+        }
+
+
+def test_generate_metadata_extracts_suggested_name():
+    result = asyncio.run(
+        generate_metadata("text", analyzer=DummyFilenameAnalyzer())
+    )
+    meta: Metadata = result["metadata"]
+    assert meta.suggested_filename == "invoice.pdf"
+    assert meta.suggested_name == "invoice"


### PR DESCRIPTION
## Summary
- derive `suggested_name` from `suggested_filename` during metadata generation
- expose `suggested_name` in `Metadata` model and verify placement uses it
- test extraction and renaming logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4611cc6a48330ba7f0ab35babeab5