### PR TITLE
Удаление даты из suggested_name и уточнение промта

### DIFF
--- a/src/file_sorter.py
+++ b/src/file_sorter.py
@@ -18,6 +18,8 @@ logger = logging.getLogger(__name__)
 
 # Запрещённые для имён файлов символы (Windows-совместимо)
 INVALID_CHARS_PATTERN = re.compile(r'[<>:"/\\|?*]')
+# Паттерн даты YYYY-MM-DD для удаления из suggested_name
+DATE_PATTERN = re.compile(r"\d{4}-\d{2}-\d{2}")
 
 
 def sanitize_filename(name: str, replacement: str = "_") -> str:
@@ -109,8 +111,9 @@ def place_file(
         base_dir.mkdir(parents=True, exist_ok=True)
 
     ext = src.suffix
-    name = metadata.get("suggested_name") or src.stem
-    name = sanitize_filename(str(name))
+    raw_name = metadata.get("suggested_name") or src.stem
+    raw_name = DATE_PATTERN.sub("", str(raw_name)).strip(" _-")
+    name = sanitize_filename(raw_name)
     metadata["suggested_name"] = name
     translit = sanitize_filename(transliterate(name))
     metadata["suggested_name_translit"] = translit

--- a/src/metadata_generation.py
+++ b/src/metadata_generation.py
@@ -104,6 +104,7 @@ class OpenRouterAnalyzer(MetadataAnalyzer):
             "Если ни одна папка не подходит, предложи новую category/subcategory.\n"
             "Return a JSON object with the fields: category, subcategory, needs_new_folder (boolean), issuer, person, doc_type,\n"
             "date, amount, tags_ru (list of strings), tags_en (list of strings), suggested_filename, description.\n"
+            "Suggested_filename must not start or end with a date (YYYY-MM-DD); provide the date only in the 'date' field.\n"
             f"Document text:\n{text}"
         )
 

--- a/tests/test_file_sorter.py
+++ b/tests/test_file_sorter.py
@@ -183,6 +183,20 @@ def test_place_file_sanitizes_invalid_chars(tmp_path):
     assert dest.name == "2023-10-12__inva_lid_na_me_.pdf"
 
 
+def test_place_file_removes_date_from_suggested_name(tmp_path):
+    src = tmp_path / "report.pdf"
+    src.write_text("content")
+
+    dest_root = tmp_path / "Archive"
+    metadata = sample_metadata()
+    metadata["suggested_name"] = "2023-10-12 Kreditvertrag"
+
+    dest, _, _ = place_file(src, metadata, dest_root, dry_run=True)
+
+    assert dest.name == "2023-10-12__Kreditvertrag.pdf"
+    assert dest.name.count("2023-10-12") == 1
+
+
 def test_place_file_returns_missing_dirs_and_does_not_move_when_needs_new_folder_false(tmp_path):
     src = tmp_path / "document.pdf"
     src.write_text("content")


### PR DESCRIPTION
## Summary
- remove date fragments from `suggested_name` before composing final file name
- clarify metadata generation prompt to avoid leading or trailing dates in `suggested_filename`
- add regression test for duplicate date handling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4661f429083308ada4d991233ad41