### PR TITLE
Объединение тегов и обновление тестов

### DIFF
--- a/src/metadata_generation.py
+++ b/src/metadata_generation.py
@@ -103,7 +103,7 @@ class OpenRouterAnalyzer(MetadataAnalyzer):
             f"{tree_json}\n"
             "Если ни одна папка не подходит, предложи новую category/subcategory.\n"
             "Return a JSON object with the fields: category, subcategory, needs_new_folder (boolean), issuer, person, doc_type,\n"
-            "date, amount, tags_ru (list of strings), tags_en (list of strings), suggested_filename, description.\n"
+            "date, amount, tags (list of strings), tags_ru (list of strings), tags_en (list of strings), suggested_filename, description.\n"
             f"Document text:\n{text}"
         )
 
@@ -206,6 +206,15 @@ async def generate_metadata(
         for key in ("date_of_birth", "expiration_date", "passport_number"):
             if mrz_info.get(key):
                 defaults[key] = mrz_info[key]
+
+    tag_values = []
+    for key in ("tags", "tags_ru", "tags_en"):
+        tag_values.extend(defaults.get(key) or [])
+    for key in ("category", "subcategory", "doc_type", "issuer", "person"):
+        value = defaults.get(key)
+        if value:
+            tag_values.append(value)
+    defaults["tags"] = list(dict.fromkeys(tag for tag in tag_values if tag))
     metadata_model = Metadata(**defaults)
     return {
         "prompt": result.get("prompt"),

--- a/tests/test_metadata_generation.py
+++ b/tests/test_metadata_generation.py
@@ -106,8 +106,14 @@ def test_multilanguage_tags_parsing(monkeypatch):
 
         def json(self) -> Dict[str, Any]:  # type: ignore[override]
             data = {
+                "tags": ["base"],
                 "tags_ru": ["тег1", "тег2"],
                 "tags_en": ["tag1", "tag2"],
+                "category": "Категория",
+                "subcategory": "Подкатегория",
+                "doc_type": "Тип",
+                "issuer": "Организация",
+                "person": "Иван Иванов",
             }
             return {"choices": [{"message": {"content": json.dumps(data)}}]}
 
@@ -122,6 +128,19 @@ def test_multilanguage_tags_parsing(monkeypatch):
     meta: Metadata = result["metadata"]
     assert meta.tags_ru == ["тег1", "тег2"]
     assert meta.tags_en == ["tag1", "tag2"]
+    expected = {
+        "base",
+        "тег1",
+        "тег2",
+        "tag1",
+        "tag2",
+        "Категория",
+        "Подкатегория",
+        "Тип",
+        "Организация",
+        "Иван Иванов",
+    }
+    assert expected.issubset(set(meta.tags))
 
 
 def test_generate_metadata_parses_mrz():


### PR DESCRIPTION
## Summary
- добавлено поле `tags` в запрос к LLM
- объединение тегов из разных источников и добавление ключевых метаданных в `tags`
- расширены тесты для проверки итогового списка тегов

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4662626348330945134820827ffb2