### PR TITLE
Reorder path structure to put person first

### DIFF
--- a/src/docrouter.py
+++ b/src/docrouter.py
@@ -36,7 +36,12 @@ async def process_directory(
             else:
                 metadata = raw_meta.model_dump()
             rel_dir = path.parent.relative_to(input_path)
-            dest_base = Path(dest_root) / rel_dir
+            rel_parts = list(rel_dir.parts)
+            if rel_parts and not metadata.get("category"):
+                metadata["category"] = rel_parts[0]
+            if len(rel_parts) > 1 and not metadata.get("subcategory"):
+                metadata["subcategory"] = rel_parts[1]
+            dest_base = Path(dest_root)
             dest_base.mkdir(parents=True, exist_ok=True)
             place_file(
                 path,

--- a/src/file_sorter.py
+++ b/src/file_sorter.py
@@ -76,7 +76,7 @@ def place_file(
 ) -> Tuple[Path, List[str], bool]:
     """Переместить файл в структуру папок на основе *metadata*.
 
-    Структура: ``<dest_root>/<category>/<subcategory>/<person>/<issuer>/<DATE>__<NAME>.<ext>``.
+    Структура: ``<dest_root>/<person>/<category>/<subcategory>/<issuer>/<DATE>__<NAME>.<ext>``.
     Рядом с файлом сохраняется ``.json`` с теми же метаданными.
 
     Возвращает кортеж ``(dest_file, missing, confirmed)``, где:
@@ -122,20 +122,20 @@ def place_file(
     dest_dir = base_dir
     missing: List[str] = []
 
-    # Сначала category/subcategory
+    # Сначала person (или общий)
+    person = metadata.get("person") or GENERAL_FOLDER_NAME
+    metadata["person"] = person
+    dest_dir /= str(person)
+    if not dest_dir.exists():
+        missing.append(str(dest_dir.relative_to(base_dir)))
+
+    # Затем category/subcategory
     for key in ("category", "subcategory"):
         value = metadata.get(key)
         if value:
             dest_dir /= str(value)
             if not dest_dir.exists():
                 missing.append(str(dest_dir.relative_to(base_dir)))
-
-    # Затем person (или общий)
-    person = metadata.get("person") or GENERAL_FOLDER_NAME
-    metadata["person"] = person
-    dest_dir /= str(person)
-    if not dest_dir.exists():
-        missing.append(str(dest_dir.relative_to(base_dir)))
 
     # Затем issuer (если есть)
     issuer = metadata.get("issuer")

--- a/tests/test_docrouter_recursive.py
+++ b/tests/test_docrouter_recursive.py
@@ -24,6 +24,6 @@ def test_process_directory_preserves_subdirs(tmp_path, monkeypatch):
     dest_root = tmp_path / "Archive"
     asyncio.run(process_directory(tmp_path / "input", dest_root))
 
-    expected = dest_root / "sub1" / "sub2" / GENERAL_FOLDER_NAME / "2024-01-01__data.txt"
+    expected = dest_root / GENERAL_FOLDER_NAME / "sub1" / "sub2" / "2024-01-01__data.txt"
     assert expected.exists()
     assert not file_path.exists()

--- a/tests/test_file_sorter.py
+++ b/tests/test_file_sorter.py
@@ -30,18 +30,18 @@ def test_place_file_path_and_name(tmp_path):
 
     expected = (
         dest_root
+        / GENERAL_FOLDER_NAME
         / "Финансы"
         / "Банки"
-        / GENERAL_FOLDER_NAME
         / "Sparkasse"
         / "2023-10-12__Kreditvertrag.pdf"
     )
     assert dest == expected
     assert missing == [
-        "Финансы",
-        "Финансы/Банки",
-        f"Финансы/Банки/{GENERAL_FOLDER_NAME}",
-        f"Финансы/Банки/{GENERAL_FOLDER_NAME}/Sparkasse",
+        f"{GENERAL_FOLDER_NAME}",
+        f"{GENERAL_FOLDER_NAME}/Финансы",
+        f"{GENERAL_FOLDER_NAME}/Финансы/Банки",
+        f"{GENERAL_FOLDER_NAME}/Финансы/Банки/Sparkasse",
     ]
 
 
@@ -56,18 +56,18 @@ def test_place_file_uses_person_folder(tmp_path):
 
     expected = (
         dest_root
+        / "Alice"
         / "Финансы"
         / "Банки"
-        / "Alice"
         / "Sparkasse"
         / "2023-10-12__Kreditvertrag.pdf"
     )
     assert dest == expected
     assert missing == [
-        "Финансы",
-        "Финансы/Банки",
-        "Финансы/Банки/Alice",
-        "Финансы/Банки/Alice/Sparkasse",
+        "Alice",
+        "Alice/Финансы",
+        "Alice/Финансы/Банки",
+        "Alice/Финансы/Банки/Sparkasse",
     ]
 
 
@@ -81,14 +81,14 @@ def test_place_file_uses_person_from_metadata(tmp_path):
     dest, missing, _ = place_file(src, metadata, dest_root, dry_run=True)
 
     expected = (
-        dest_root / "Финансы" / "Банки" / "Alice" / "Sparkasse" / "2023-10-12__Kreditvertrag.pdf"
+        dest_root / "Alice" / "Финансы" / "Банки" / "Sparkasse" / "2023-10-12__Kreditvertrag.pdf"
     )
     assert dest == expected
     assert missing == [
-        "Финансы",
-        "Финансы/Банки",
-        "Финансы/Банки/Alice",
-        "Финансы/Банки/Alice/Sparkasse",
+        "Alice",
+        "Alice/Финансы",
+        "Alice/Финансы/Банки",
+        "Alice/Финансы/Банки/Sparkasse",
     ]
 
 
@@ -122,9 +122,9 @@ def test_place_file_moves_and_creates_json(tmp_path):
     json_path = dest.with_suffix(dest.suffix + ".json")
     expected = (
         dest_root
+        / GENERAL_FOLDER_NAME
         / "Финансы"
         / "Банки"
-        / GENERAL_FOLDER_NAME
         / "Sparkasse"
         / "2023-10-12__Kreditvertrag.pdf"
     )
@@ -198,18 +198,18 @@ def test_place_file_returns_missing_dirs_and_does_not_move_when_needs_new_folder
 
     expected = (
         dest_root
+        / GENERAL_FOLDER_NAME
         / "Финансы"
         / "Банки"
-        / GENERAL_FOLDER_NAME
         / "Sparkasse"
         / "2023-10-12__Kreditvertrag.pdf"
     )
     assert dest == expected
     assert missing == [
-        "Финансы",
-        "Финансы/Банки",
-        f"Финансы/Банки/{GENERAL_FOLDER_NAME}",
-        f"Финансы/Банки/{GENERAL_FOLDER_NAME}/Sparkasse",
+        f"{GENERAL_FOLDER_NAME}",
+        f"{GENERAL_FOLDER_NAME}/Финансы",
+        f"{GENERAL_FOLDER_NAME}/Финансы/Банки",
+        f"{GENERAL_FOLDER_NAME}/Финансы/Банки/Sparkasse",
     ]
     # файл не должен быть перемещён
     assert not dest.exists()
@@ -247,9 +247,9 @@ def test_place_file_creates_dirs_on_confirmation(tmp_path):
 
     expected = (
         dest_root
+        / GENERAL_FOLDER_NAME
         / "Финансы"
         / "Банки"
-        / GENERAL_FOLDER_NAME
         / "Sparkasse"
         / "2023-10-12__Kreditvertrag.pdf"
     )

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -399,10 +399,10 @@ def test_upload_pending_then_finalize(tmp_path, monkeypatch):
         data = resp.json()
         assert data["status"] == "pending"
         assert data["missing"] == [
-            "Финансы",
-            "Финансы/Банки",
-            f"Финансы/Банки/{GENERAL_FOLDER_NAME}",
-            f"Финансы/Банки/{GENERAL_FOLDER_NAME}/Sparkasse",
+            f"{GENERAL_FOLDER_NAME}",
+            f"{GENERAL_FOLDER_NAME}/Финансы",
+            f"{GENERAL_FOLDER_NAME}/Финансы/Банки",
+            f"{GENERAL_FOLDER_NAME}/Финансы/Банки/Sparkasse",
         ]
         file_id = data["id"]
 


### PR DESCRIPTION
## Summary
- Build archive paths as `<dest_root>/<person>/<category>/<subcategory>/<issuer>`
- Map input subdirectories to category and subcategory when routing files
- Update tests and web API expectations for new folder order

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4661b6da88330a832a3a80d2fa036