### PR TITLE
feat: expand metadata fields and prompt template

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -16,6 +16,10 @@ class Metadata(BaseModel):
     expiration_date: Optional[str] = None
     passport_number: Optional[str] = None
     amount: Optional[str] = None
+    counterparty: Optional[str] = None
+    document_number: Optional[str] = None
+    due_date: Optional[str] = None
+    currency: Optional[str] = None
     tags: List[str] = Field(default_factory=list)
     tags_ru: List[str] = Field(default_factory=list)
     tags_en: List[str] = Field(default_factory=list)

--- a/src/prompt_templates.py
+++ b/src/prompt_templates.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, Optional
+
+
+def build_metadata_prompt(
+    text: str,
+    *,
+    folder_tree: Optional[Dict[str, Any]] = None,
+    file_info: Optional[Dict[str, Any]] = None,
+) -> str:
+    """Сформировать промт для извлечения метаданных."""
+    tree_json = json.dumps(folder_tree or {}, ensure_ascii=False)
+    info = file_info or {}
+    filename = info.get("name")
+    extension = info.get("extension")
+    size = info.get("size")
+    file_type = info.get("type")
+
+    return (
+        "You are an assistant that extracts structured metadata from documents.\n"
+        f"Original file name: {filename}\n"
+        f"Extension: {extension}\n"
+        f"Size: {size}\n"
+        f"File type: {file_type}\n"
+        "Possible document types include: contracts, receipts, notifications, advertisement.\n"
+        "Existing folder tree (JSON):\n"
+        f"{tree_json}\n"
+        "Если ни одна папка не подходит, предложи новую category/subcategory.\n"
+        "Return a JSON object with the fields: category, subcategory, needs_new_folder (boolean), issuer, person, doc_type, "
+        "date, amount, counterparty, document_number, due_date, currency, tags_ru (list of strings), tags_en (list of strings), "
+        "suggested_filename, description.\n"
+        f"Document text:\n{text}"
+    )

--- a/tests/test_metadata_generation.py
+++ b/tests/test_metadata_generation.py
@@ -11,7 +11,10 @@ from models import Metadata
 
 class DummyAnalyzer(MetadataAnalyzer):
     async def analyze(
-        self, text: str, folder_tree: Dict[str, Any] | None = None
+        self,
+        text: str,
+        folder_tree: Dict[str, Any] | None = None,
+        file_info: Dict[str, Any] | None = None,
     ) -> Dict[str, Any]:
         return {"prompt": None, "raw_response": None, "metadata": {}}
 
@@ -22,7 +25,7 @@ def test_generate_metadata_without_api_key(monkeypatch):
         asyncio.run(generate_metadata("text"))
 
 
-def test_folder_tree_in_prompt(monkeypatch):
+def test_prompt_includes_context(monkeypatch):
     captured: dict[str, str] = {}
 
     class DummyResponse:
@@ -54,13 +57,21 @@ def test_folder_tree_in_prompt(monkeypatch):
             "children": [{"name": "Банки", "path": "Финансы/Банки", "children": []}],
         }
     ]
-    result = asyncio.run(generate_metadata("text", folder_tree=tree))
+    file_info = {"name": "invoice", "extension": ".pdf", "size": 100, "type": "pdf"}
+    result = asyncio.run(
+        generate_metadata("text", folder_tree=tree, file_info=file_info)
+    )
+    prompt = captured["prompt"]
     instruction = "Если ни одна папка не подходит, предложи новую category/subcategory."
     tree_json = json.dumps(tree, ensure_ascii=False)
-    assert tree_json in captured["prompt"]
+    assert tree_json in prompt
+    assert file_info["name"] in prompt
+    assert file_info["extension"] in prompt
+    assert str(file_info["size"]) in prompt
+    assert file_info["type"] in prompt
+    assert "contracts" in prompt
+    assert instruction in prompt
     assert tree_json in result["prompt"]
-    assert instruction in captured["prompt"]
-    assert instruction in result["prompt"]
     assert result["metadata"].needs_new_folder is True
 
 
@@ -139,12 +150,21 @@ def test_generate_metadata_parses_mrz():
 
 class DummyFilenameAnalyzer(MetadataAnalyzer):
     async def analyze(
-        self, text: str, folder_tree: Dict[str, Any] | None = None
+        self,
+        text: str,
+        folder_tree: Dict[str, Any] | None = None,
+        file_info: Dict[str, Any] | None = None,
     ) -> Dict[str, Any]:
         return {
             "prompt": None,
             "raw_response": None,
-            "metadata": {"suggested_filename": "invoice.pdf"},
+            "metadata": {
+                "suggested_filename": "invoice.pdf",
+                "counterparty": "ACME",
+                "document_number": "42",
+                "due_date": "2024-12-31",
+                "currency": "EUR",
+            },
         }
 
 
@@ -155,3 +175,7 @@ def test_generate_metadata_extracts_suggested_name():
     meta: Metadata = result["metadata"]
     assert meta.suggested_filename == "invoice.pdf"
     assert meta.suggested_name == "invoice"
+    assert meta.counterparty == "ACME"
+    assert meta.document_number == "42"
+    assert meta.due_date == "2024-12-31"
+    assert meta.currency == "EUR"


### PR DESCRIPTION
## Summary
- add prompt template including file metadata and document type hints
- extend metadata model and generation with counterparty, document_number, due_date and currency
- cover new fields and prompt context in tests

## Testing
- `python -m pytest` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68b4662d97cc83308e65aab1c2ce0fbb