### PR TITLE
Обработка неизвестной даты и парсинг даты военного билета

### DIFF
--- a/src/file_sorter.py
+++ b/src/file_sorter.py
@@ -117,7 +117,7 @@ def place_file(
     metadata["suggested_name"] = name
     translit = sanitize_filename(transliterate(name))
     metadata["suggested_name_translit"] = translit
-    date = metadata.get("date", "unknown-date")
+    date = metadata.get("date") or "unknown-date"
 
     base_new_name = f"{date}__{name}"
     base_translit = f"{date}__{translit}"

--- a/src/metadata_generation.py
+++ b/src/metadata_generation.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 import json
 import logging
+import re
+from datetime import datetime
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any, Dict, Optional, Callable
@@ -29,6 +31,29 @@ from config import (
 
 from services.openrouter import OpenRouterError
 from file_utils.mrz import parse_mrz
+
+
+MILITARY_DATE_PATTERN = re.compile(
+    r"(?:дата\s+выдачи|действителен\s+до)[:\s]*"
+    r"([0-3]?\d[\.\/-][0-1]?\d[\.\/-][1-2]\d{3})",
+    re.IGNORECASE,
+)
+
+
+def parse_military_id_date(text: str) -> Optional[str]:
+    """Вытащить дату из текста военного билета."""
+    if "военный билет" not in text.lower():
+        return None
+    match = MILITARY_DATE_PATTERN.search(text)
+    if not match:
+        return None
+    date_str = match.group(1)
+    for fmt in ("%d.%m.%Y", "%d-%m-%Y", "%d/%m/%Y"):
+        try:
+            return datetime.strptime(date_str, fmt).date().isoformat()
+        except ValueError:
+            continue
+    return None
 
 
 logger = logging.getLogger(__name__)
@@ -109,6 +134,7 @@ class OpenRouterAnalyzer(MetadataAnalyzer):
             "temperature": 0.1,
             # OpenRouter совместим с OpenAI; просим строгий JSON
             "response_format": {"type": "json_object"},
+            "extra_body": {"response_format": {"type": "json_object"}},
         }
         headers = {
             "Authorization": f"Bearer {self.api_key}",
@@ -218,8 +244,13 @@ async def generate_metadata(
         "suggested_filename": None,
         "description": None,
         "needs_new_folder": False,
-    }
+    } 
     defaults.update(metadata or {})
+
+    if not defaults.get("date"):
+        military_date = parse_military_id_date(text)
+        if military_date:
+            defaults["date"] = military_date
 
     # Вытаскиваем stem для suggested_name
     suggested_filename = defaults.get("suggested_filename")

--- a/tests/test_file_sorter.py
+++ b/tests/test_file_sorter.py
@@ -272,3 +272,18 @@ def test_place_file_creates_dirs_on_confirmation(tmp_path):
     assert dest == expected
     assert dest.exists()
     assert dest.parent.exists()
+
+
+def test_place_file_handles_missing_and_valid_date(tmp_path):
+    src = tmp_path / "doc.pdf"
+    src.write_text("data")
+
+    dest_root = tmp_path / "Archive"
+    metadata = sample_metadata()
+    metadata["date"] = None
+    dest, _, _ = place_file(src, metadata, dest_root, dry_run=True)
+    assert dest.name.startswith("unknown-date__")
+
+    metadata["date"] = "2024-07-05"
+    dest2, _, _ = place_file(src, metadata, dest_root, dry_run=True)
+    assert dest2.name.startswith("2024-07-05__")

--- a/tests/test_metadata_generation.py
+++ b/tests/test_metadata_generation.py
@@ -198,3 +198,10 @@ def test_generate_metadata_extracts_suggested_name():
     assert meta.document_number == "42"
     assert meta.due_date == "2024-12-31"
     assert meta.currency == "EUR"
+
+
+def test_generate_metadata_parses_military_id_date():
+    text = "Военный билет\nДата выдачи: 15.04.2020"
+    result = asyncio.run(generate_metadata(text, analyzer=DummyAnalyzer()))
+    meta: Metadata = result["metadata"]
+    assert meta.date == "2020-04-15"


### PR DESCRIPTION
## Summary
- Обеспечена подстановка `unknown-date` при отсутствии даты в метаданных
- Добавлен парсинг даты выдачи/действительности военного билета и сохранение в поле `date`
- Дополнены тесты для проверки имени файла и парсинга даты

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b4699621388330b7556ea91fe81d92