### PR TITLE
Improve modal accessibility and focus management

### DIFF
--- a/src/web_app/static/chat.ts
+++ b/src/web_app/static/chat.ts
@@ -3,6 +3,7 @@ let chatHistory: HTMLElement;
 let chatForm: HTMLFormElement | null;
 let chatInput: HTMLInputElement | null;
 let currentChatId: string | null = null;
+let lastFocused: HTMLElement | null = null;
 
 export function setupChat() {
   chatModal = document.getElementById('chat-modal')!;
@@ -48,10 +49,54 @@ export async function openChatModal(file: any) {
   } catch {
     renderChat([]);
   }
-  chatModal.style.display = 'flex';
+  openModal(chatModal);
 }
 
 export function closeChat() {
-  chatModal.style.display = 'none';
+  closeModal(chatModal);
   currentChatId = null;
+}
+
+function openModal(modal: HTMLElement) {
+  lastFocused = document.activeElement as HTMLElement;
+  modal.style.display = 'flex';
+  const focusable = modal.querySelectorAll<HTMLElement>(
+    'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+  );
+  const first = (focusable[0] || modal) as HTMLElement;
+  if (typeof (first as any).focus === 'function') {
+    (first as any).focus();
+  }
+  const handleKeydown = (e: KeyboardEvent) => {
+    if (e.key === 'Tab') {
+      const items = modal.querySelectorAll<HTMLElement>(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+      );
+      if (!items.length) return;
+      const firstEl = items[0];
+      const lastEl = items[items.length - 1];
+      if (e.shiftKey && document.activeElement === firstEl) {
+        e.preventDefault();
+        lastEl.focus();
+      } else if (!e.shiftKey && document.activeElement === lastEl) {
+        e.preventDefault();
+        firstEl.focus();
+      }
+    } else if (e.key === 'Escape') {
+      closeChat();
+    }
+  };
+  modal.addEventListener('keydown', handleKeydown);
+  (modal as any)._handleKeydown = handleKeydown;
+}
+
+function closeModal(modal: HTMLElement) {
+  modal.style.display = 'none';
+  const handler = (modal as any)._handleKeydown;
+  if (handler && typeof (modal as any).removeEventListener === 'function') {
+    modal.removeEventListener('keydown', handler);
+  }
+  (modal as any)._handleKeydown = null;
+  lastFocused?.focus();
+  lastFocused = null;
 }

--- a/src/web_app/static/dist/chat.js
+++ b/src/web_app/static/dist/chat.js
@@ -12,6 +12,7 @@ let chatHistory;
 let chatForm;
 let chatInput;
 let currentChatId = null;
+let lastFocused = null;
 export function setupChat() {
     chatModal = document.getElementById('chat-modal');
     chatHistory = document.getElementById('chat-history');
@@ -57,10 +58,51 @@ export function openChatModal(file) {
         catch (_a) {
             renderChat([]);
         }
-        chatModal.style.display = 'flex';
+        openModal(chatModal);
     });
 }
 export function closeChat() {
-    chatModal.style.display = 'none';
+    closeModal(chatModal);
     currentChatId = null;
+}
+function openModal(modal) {
+    lastFocused = document.activeElement;
+    modal.style.display = 'flex';
+    const focusable = modal.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
+    const first = (focusable[0] || modal);
+    if (typeof first.focus === 'function') {
+        first.focus();
+    }
+    const handleKeydown = (e) => {
+        if (e.key === 'Tab') {
+            const items = modal.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
+            if (!items.length)
+                return;
+            const firstEl = items[0];
+            const lastEl = items[items.length - 1];
+            if (e.shiftKey && document.activeElement === firstEl) {
+                e.preventDefault();
+                lastEl.focus();
+            }
+            else if (!e.shiftKey && document.activeElement === lastEl) {
+                e.preventDefault();
+                firstEl.focus();
+            }
+        }
+        else if (e.key === 'Escape') {
+            closeChat();
+        }
+    };
+    modal.addEventListener('keydown', handleKeydown);
+    modal._handleKeydown = handleKeydown;
+}
+function closeModal(modal) {
+    modal.style.display = 'none';
+    const handler = modal._handleKeydown;
+    if (handler && typeof modal.removeEventListener === 'function') {
+        modal.removeEventListener('keydown', handler);
+    }
+    modal._handleKeydown = null;
+    lastFocused === null || lastFocused === void 0 ? void 0 : lastFocused.focus();
+    lastFocused = null;
 }

--- a/src/web_app/static/dist/upload.js
+++ b/src/web_app/static/dist/upload.js
@@ -30,6 +30,7 @@ let saveBtn;
 let cropper = null;
 let currentImageIndex = -1;
 let imageFiles = [];
+let lastFocused = null;
 export function setupUpload() {
     form = document.querySelector('form');
     progress = document.getElementById('upload-progress');
@@ -61,7 +62,7 @@ export function setupUpload() {
                 imageFiles[currentImageIndex] = { blob, name };
                 renderImageList();
             }
-            imageEditModal.style.display = 'none';
+            closeModal(imageEditModal);
             cropper.destroy();
             cropper = null;
             const nextIndex = currentImageIndex + 1;
@@ -104,7 +105,7 @@ export function setupUpload() {
                         li.textContent = path;
                         missingList.appendChild(li);
                     });
-                    missingModal.style.display = 'flex';
+                    openModal(missingModal);
                     missingConfirm.onclick = () => __awaiter(this, void 0, void 0, function* () {
                         try {
                             const resp = yield fetch(`/files/${result.id}/finalize`, {
@@ -115,7 +116,7 @@ export function setupUpload() {
                             if (!resp.ok)
                                 throw new Error();
                             const finalData = yield resp.json();
-                            missingModal.style.display = 'none';
+                            closeModal(missingModal);
                             sent.textContent = finalData.prompt || '';
                             received.textContent = finalData.raw_response || '';
                             form.reset();
@@ -185,14 +186,17 @@ export function setupUpload() {
     }
     imageDropArea.addEventListener('click', () => imageInput.click());
     uploadImagesBtn.addEventListener('click', () => uploadEditedImages());
-    document.addEventListener('keydown', (e) => {
-        if (e.key !== 'Escape')
-            return;
-        if (imageEditModal.style.display === 'flex') {
-            imageEditModal.style.display = 'none';
-        }
-        if (missingModal.style.display === 'flex') {
-            missingModal.style.display = 'none';
+    const editClose = imageEditModal.querySelector('.close');
+    editClose === null || editClose === void 0 ? void 0 : editClose.addEventListener('click', () => {
+        closeModal(imageEditModal);
+        cropper === null || cropper === void 0 ? void 0 : cropper.destroy();
+        cropper = null;
+    });
+    imageEditModal.addEventListener('click', (e) => {
+        if (e.target === imageEditModal) {
+            closeModal(imageEditModal);
+            cropper === null || cropper === void 0 ? void 0 : cropper.destroy();
+            cropper = null;
         }
     });
 }
@@ -223,7 +227,7 @@ function openImageEditModal(fileObj) {
         URL.revokeObjectURL(url);
     };
     img.src = url;
-    imageEditModal.style.display = 'flex';
+    openModal(imageEditModal);
 }
 function uploadEditedImages() {
     return __awaiter(this, void 0, void 0, function* () {
@@ -250,4 +254,49 @@ function uploadEditedImages() {
             alert('Ошибка загрузки');
         }
     });
+}
+function openModal(modal) {
+    lastFocused = document.activeElement;
+    modal.style.display = 'flex';
+    const focusable = modal.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
+    const first = (focusable[0] || modal);
+    if (typeof first.focus === 'function') {
+        first.focus();
+    }
+    const handleKeydown = (e) => {
+        if (e.key === 'Tab') {
+            const items = modal.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
+            if (!items.length)
+                return;
+            const firstEl = items[0];
+            const lastEl = items[items.length - 1];
+            if (e.shiftKey && document.activeElement === firstEl) {
+                e.preventDefault();
+                lastEl.focus();
+            }
+            else if (!e.shiftKey && document.activeElement === lastEl) {
+                e.preventDefault();
+                firstEl.focus();
+            }
+        }
+        else if (e.key === 'Escape') {
+            closeModal(modal);
+            if (modal === imageEditModal) {
+                cropper === null || cropper === void 0 ? void 0 : cropper.destroy();
+                cropper = null;
+            }
+        }
+    };
+    modal.addEventListener('keydown', handleKeydown);
+    modal._handleKeydown = handleKeydown;
+}
+function closeModal(modal) {
+    modal.style.display = 'none';
+    const handler = modal._handleKeydown;
+    if (handler && typeof modal.removeEventListener === 'function') {
+        modal.removeEventListener('keydown', handler);
+    }
+    modal._handleKeydown = null;
+    lastFocused === null || lastFocused === void 0 ? void 0 : lastFocused.focus();
+    lastFocused = null;
 }

--- a/src/web_app/static/upload.ts
+++ b/src/web_app/static/upload.ts
@@ -22,6 +22,7 @@ let saveBtn: HTMLElement | null;
 let cropper: any = null;
 let currentImageIndex = -1;
 let imageFiles: Array<{ blob: Blob; name: string }> = [];
+let lastFocused: HTMLElement | null = null;
 
 export function setupUpload() {
   form = document.querySelector('form') as HTMLFormElement;
@@ -54,7 +55,7 @@ export function setupUpload() {
         imageFiles[currentImageIndex] = { blob, name };
         renderImageList();
       }
-      imageEditModal.style.display = 'none';
+      closeModal(imageEditModal);
       cropper.destroy();
       cropper = null;
       const nextIndex = currentImageIndex + 1;
@@ -96,7 +97,7 @@ export function setupUpload() {
             li.textContent = path;
             missingList.appendChild(li);
           });
-          missingModal.style.display = 'flex';
+          openModal(missingModal);
           missingConfirm.onclick = async () => {
             try {
               const resp = await fetch(`/files/${result.id}/finalize`, {
@@ -106,7 +107,7 @@ export function setupUpload() {
               });
               if (!resp.ok) throw new Error();
               const finalData = await resp.json();
-              missingModal.style.display = 'none';
+              closeModal(missingModal);
               sent.textContent = finalData.prompt || '';
               received.textContent = finalData.raw_response || '';
               form.reset();
@@ -178,14 +179,17 @@ export function setupUpload() {
   }
   imageDropArea.addEventListener('click', () => imageInput.click());
   uploadImagesBtn.addEventListener('click', () => uploadEditedImages());
-
-  document.addEventListener('keydown', (e) => {
-    if (e.key !== 'Escape') return;
-    if (imageEditModal.style.display === 'flex') {
-      imageEditModal.style.display = 'none';
-    }
-    if (missingModal.style.display === 'flex') {
-      missingModal.style.display = 'none';
+  const editClose = imageEditModal.querySelector('.close') as HTMLElement | null;
+  editClose?.addEventListener('click', () => {
+    closeModal(imageEditModal);
+    cropper?.destroy();
+    cropper = null;
+  });
+  imageEditModal.addEventListener('click', (e) => {
+    if (e.target === imageEditModal) {
+      closeModal(imageEditModal);
+      cropper?.destroy();
+      cropper = null;
     }
   });
 }
@@ -217,7 +221,7 @@ function openImageEditModal(fileObj: { blob: Blob; name: string }) {
     URL.revokeObjectURL(url);
   };
   img.src = url;
-  imageEditModal.style.display = 'flex';
+  openModal(imageEditModal);
 }
 
 async function uploadEditedImages() {
@@ -241,4 +245,52 @@ async function uploadEditedImages() {
   } else {
     alert('Ошибка загрузки');
   }
+}
+
+function openModal(modal: HTMLElement) {
+  lastFocused = document.activeElement as HTMLElement;
+  modal.style.display = 'flex';
+  const focusable = modal.querySelectorAll<HTMLElement>(
+    'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+  );
+  const first = (focusable[0] || modal) as HTMLElement;
+  if (typeof (first as any).focus === 'function') {
+    (first as any).focus();
+  }
+  const handleKeydown = (e: KeyboardEvent) => {
+    if (e.key === 'Tab') {
+      const items = modal.querySelectorAll<HTMLElement>(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+      );
+      if (!items.length) return;
+      const firstEl = items[0];
+      const lastEl = items[items.length - 1];
+      if (e.shiftKey && document.activeElement === firstEl) {
+        e.preventDefault();
+        lastEl.focus();
+      } else if (!e.shiftKey && document.activeElement === lastEl) {
+        e.preventDefault();
+        firstEl.focus();
+      }
+    } else if (e.key === 'Escape') {
+      closeModal(modal);
+      if (modal === imageEditModal) {
+        cropper?.destroy();
+        cropper = null;
+      }
+    }
+  };
+  modal.addEventListener('keydown', handleKeydown);
+  (modal as any)._handleKeydown = handleKeydown;
+}
+
+function closeModal(modal: HTMLElement) {
+  modal.style.display = 'none';
+  const handler = (modal as any)._handleKeydown;
+  if (handler && typeof (modal as any).removeEventListener === 'function') {
+    modal.removeEventListener('keydown', handler);
+  }
+  (modal as any)._handleKeydown = null;
+  lastFocused?.focus();
+  lastFocused = null;
 }

--- a/src/web_app/templates/index.html
+++ b/src/web_app/templates/index.html
@@ -79,9 +79,9 @@
         </div>
     </div>
 
-    <div id="edit-modal" class="modal">
+    <div id="edit-modal" class="modal" role="dialog" aria-modal="true">
         <div class="modal-content">
-            <span class="close" data-close="edit-modal">&times;</span>
+            <span class="close" data-close="edit-modal" aria-label="Закрыть">&times;</span>
             <canvas id="edit-canvas"></canvas>
             <div class="modal-buttons">
                 <button id="rotate-left-btn" type="button">Повернуть влево</button>
@@ -91,9 +91,9 @@
         </div>
     </div>
 
-    <div id="metadata-modal" class="modal">
+    <div id="metadata-modal" class="modal" role="dialog" aria-modal="true">
         <div class="modal-content">
-            <span class="close" data-close="metadata-modal">&times;</span>
+            <span class="close" data-close="metadata-modal" aria-label="Закрыть">&times;</span>
             <h3>Редактировать метаданные</h3>
             <form id="edit-form">
                 <label>Категория: <input type="text" id="edit-category" /></label>
@@ -110,7 +110,7 @@
         </div>
     </div>
 
-    <div id="missing-modal" class="modal">
+    <div id="missing-modal" class="modal" role="dialog" aria-modal="true">
         <div class="modal-content">
             <h3>Создать недостающие папки?</h3>
             <p id="suggested-path"></p>
@@ -119,33 +119,33 @@
         </div>
     </div>
 
-    <div id="rename-modal" class="modal">
+    <div id="rename-modal" class="modal" role="dialog" aria-modal="true">
         <div class="modal-content">
-            <span class="close" data-close="rename-modal">&times;</span>
+            <span class="close" data-close="rename-modal" aria-label="Закрыть">&times;</span>
             <h3>Переименовать папку</h3>
             <input type="text" id="rename-input" />
             <button id="rename-confirm">Сохранить</button>
         </div>
     </div>
 
-    <div id="delete-modal" class="modal">
+    <div id="delete-modal" class="modal" role="dialog" aria-modal="true">
         <div class="modal-content">
-            <span class="close" data-close="delete-modal">&times;</span>
+            <span class="close" data-close="delete-modal" aria-label="Закрыть">&times;</span>
             <p>Удалить папку <span id="delete-target"></span>?</p>
             <button id="delete-confirm">Удалить</button>
         </div>
     </div>
 
-    <div id="preview-modal" class="modal">
+    <div id="preview-modal" class="modal" role="dialog" aria-modal="true">
         <div class="modal-content">
-            <span class="close" data-close="preview-modal">&times;</span>
+            <span class="close" data-close="preview-modal" aria-label="Закрыть">&times;</span>
             <iframe id="preview-frame"></iframe>
         </div>
     </div>
 
-    <div id="chat-modal" class="modal">
+    <div id="chat-modal" class="modal" role="dialog" aria-modal="true">
         <div class="modal-content">
-            <span class="close" data-close="chat-modal">&times;</span>
+            <span class="close" data-close="chat-modal" aria-label="Закрыть">&times;</span>
             <div id="chat-history"></div>
             <form id="chat-form">
                 <input type="text" id="chat-input" placeholder="Сообщение" />


### PR DESCRIPTION
## Summary
- add `role="dialog"`, `aria-modal="true"` and close button labels to all modals
- implement focus management, focus trapping and Escape handling for modals

## Testing
- `npm run build`
- `pytest` *(fails: tests/test_metadata_generation.py::test_response_format_in_extra_body)*

------
https://chatgpt.com/codex/tasks/task_e_68b46a4653d48330a4a7ade223987113