### PR TITLE
Добавлен модуль уведомлений и замена alert

### DIFF
--- a/src/web_app/static/dist/files.js
+++ b/src/web_app/static/dist/files.js
@@ -8,6 +8,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 import { openChatModal } from './chat.js';
+import { showError } from './notifications.js';
 let list;
 let textPreview;
 let tagLanguage;
@@ -77,7 +78,7 @@ export function setupFiles() {
             yield refreshFiles();
         }
         else {
-            alert('Ошибка обновления');
+            showError('Ошибка обновления');
         }
     }));
     list.addEventListener('click', (e) => __awaiter(this, void 0, void 0, function* () {

--- a/src/web_app/static/dist/notifications.js
+++ b/src/web_app/static/dist/notifications.js
@@ -1,0 +1,28 @@
+export function showError(message) {
+    show(message, 'error');
+}
+export function showInfo(message) {
+    show(message, 'info');
+}
+function show(message, type) {
+    const container = document.getElementById('notifications');
+    if (!container) {
+        if (type === 'error')
+            console.error(message);
+        else
+            console.log(message);
+        return;
+    }
+    const div = document.createElement('div');
+    div.className = `notification ${type}`;
+    div.textContent = message;
+    container.appendChild(div);
+    setTimeout(() => {
+        if (typeof div.remove === 'function') {
+            div.remove();
+        }
+        else if (div.parentNode && typeof div.parentNode.removeChild === 'function') {
+            div.parentNode.removeChild(div);
+        }
+    }, 5000);
+}

--- a/src/web_app/static/dist/upload.js
+++ b/src/web_app/static/dist/upload.js
@@ -9,6 +9,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 import { refreshFiles } from './files.js';
 import { refreshFolderTree } from './folders.js';
+import { showError } from './notifications.js';
 let form;
 let progress;
 let sent;
@@ -80,7 +81,7 @@ export function setupUpload() {
         const fileInput = form.querySelector('input[type="file"]');
         const file = (_a = fileInput === null || fileInput === void 0 ? void 0 : fileInput.files) === null || _a === void 0 ? void 0 : _a[0];
         if (!file || !file.name) {
-            alert('Файл должен иметь имя');
+            showError('Файл должен иметь имя');
             return;
         }
         const data = new FormData(form);
@@ -124,7 +125,7 @@ export function setupUpload() {
                             refreshFolderTree();
                         }
                         catch (_a) {
-                            alert('Ошибка обработки');
+                            showError('Ошибка обработки');
                         }
                     });
                 }
@@ -138,7 +139,7 @@ export function setupUpload() {
                 }
             }
             else {
-                alert('Ошибка загрузки');
+                showError('Ошибка загрузки');
             }
         };
         xhr.send(data);
@@ -247,7 +248,7 @@ function uploadEditedImages() {
             refreshFolderTree();
         }
         else {
-            alert('Ошибка загрузки');
+            showError('Ошибка загрузки');
         }
     });
 }

--- a/src/web_app/static/files.ts
+++ b/src/web_app/static/files.ts
@@ -1,4 +1,5 @@
 import { openChatModal } from './chat.js';
+import { showError } from './notifications.js';
 
 let list: HTMLElement;
 let textPreview: HTMLElement;
@@ -69,7 +70,7 @@ export function setupFiles() {
       currentEditId = null;
       await refreshFiles();
     } else {
-      alert('Ошибка обновления');
+      showError('Ошибка обновления');
     }
   });
 

--- a/src/web_app/static/notifications.ts
+++ b/src/web_app/static/notifications.ts
@@ -1,0 +1,27 @@
+export function showError(message: string) {
+  show(message, 'error');
+}
+
+export function showInfo(message: string) {
+  show(message, 'info');
+}
+
+function show(message: string, type: 'error' | 'info') {
+  const container = document.getElementById('notifications');
+  if (!container) {
+    if (type === 'error') console.error(message);
+    else console.log(message);
+    return;
+  }
+  const div = document.createElement('div');
+  div.className = `notification ${type}`;
+  div.textContent = message;
+  container.appendChild(div);
+  setTimeout(() => {
+    if (typeof (div as any).remove === 'function') {
+      (div as any).remove();
+    } else if ((div as any).parentNode && typeof (div as any).parentNode.removeChild === 'function') {
+      (div as any).parentNode.removeChild(div);
+    }
+  }, 5000);
+}

--- a/src/web_app/static/style.css
+++ b/src/web_app/static/style.css
@@ -97,3 +97,24 @@ button:hover, input[type="submit"]:hover { background-color: #0056b3; }
   #edit-modal .modal-buttons { flex-direction: column; }
   .modal-content { width: 100%; max-width: none; }
 }
+
+#notifications {
+  position: fixed;
+  top: 1em;
+  right: 1em;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5em;
+  z-index: 1000;
+}
+
+.notification {
+  padding: 0.5em 1em;
+  border-radius: 4px;
+  color: #fff;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+}
+
+.notification.error { background-color: #dc3545; }
+
+.notification.info { background-color: #17a2b8; }

--- a/src/web_app/static/upload.ts
+++ b/src/web_app/static/upload.ts
@@ -1,5 +1,6 @@
 import { refreshFiles } from './files.js';
 import { refreshFolderTree } from './folders.js';
+import { showError } from './notifications.js';
 
 let form: HTMLFormElement;
 let progress: HTMLProgressElement;
@@ -72,7 +73,7 @@ export function setupUpload() {
     const fileInput = form.querySelector('input[type="file"]') as HTMLInputElement;
     const file = fileInput?.files?.[0];
     if (!file || !file.name) {
-      alert('Файл должен иметь имя');
+      showError('Файл должен иметь имя');
       return;
     }
     const data = new FormData(form);
@@ -114,7 +115,7 @@ export function setupUpload() {
               refreshFiles();
               refreshFolderTree();
             } catch {
-              alert('Ошибка обработки');
+              showError('Ошибка обработки');
             }
           };
         } else {
@@ -126,7 +127,7 @@ export function setupUpload() {
           refreshFolderTree();
         }
       } else {
-        alert('Ошибка загрузки');
+        showError('Ошибка загрузки');
       }
     };
     xhr.send(data);
@@ -239,6 +240,6 @@ async function uploadEditedImages() {
     refreshFiles();
     refreshFolderTree();
   } else {
-    alert('Ошибка загрузки');
+    showError('Ошибка загрузки');
   }
 }

--- a/src/web_app/templates/index.html
+++ b/src/web_app/templates/index.html
@@ -11,6 +11,7 @@
     <script type="module" src="/static/dist/main.js"></script>
 </head>
 <body>
+    <div id="notifications"></div>
     <div class="container">
         <h1>Загрузка документов</h1>
         <p>Выберите файл и отправьте его на обработку.</p>


### PR DESCRIPTION
## Summary
- Добавлен контейнер `notifications` и модуль с функциями `showError`/`showInfo`
- Заменены `alert` на `showError` в upload/files, обновлён стиль уведомлений

## Testing
- `npm run build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b46b09d2788330bc2918bb0c37988e