### PR TITLE
feat: unify upload button

### DIFF
--- a/src/web_app/static/dist/imageBatch.js
+++ b/src/web_app/static/dist/imageBatch.js
@@ -13,58 +13,40 @@ import { openImageEditModal } from './imageEditor.js';
 import { sent, received } from './uploadForm.js';
 export let currentImageIndex = -1;
 export let imageFiles = [];
-let imageInput;
-let imageDropArea;
-let selectImagesBtn;
+let fileInput;
 let imageList;
 let uploadImagesBtn;
+let imageBlock;
+let singleUploadBtn;
 export function setupImageBatch() {
-    imageInput = document.getElementById('image-files');
-    imageDropArea = document.getElementById('image-drop-area');
-    selectImagesBtn = document.getElementById('select-images-btn');
+    fileInput = document.getElementById('file-input');
     imageList = document.getElementById('selected-images');
     uploadImagesBtn = document.getElementById('upload-images-btn');
-    imageInput.addEventListener('change', (e) => {
-        const files = Array.from(e.target.files || []).filter(f => f.type === 'image/jpeg');
-        if (files.length) {
+    imageBlock = document.getElementById('image-upload-block');
+    singleUploadBtn = document.getElementById('single-upload-btn');
+    fileInput.addEventListener('change', () => {
+        const files = Array.from(fileInput.files || []);
+        const allJPEG = files.length > 0 && files.every(f => f.type === 'image/jpeg');
+        if (allJPEG) {
             imageFiles = files.map(f => ({ blob: f, name: f.name }));
             currentImageIndex = 0;
             renderImageList();
+            imageBlock.style.display = 'block';
+            singleUploadBtn.style.display = 'none';
             openImageEditModal(imageFiles[0]);
         }
-    });
-    const isTouchDevice = typeof window.matchMedia === 'function' && window.matchMedia('(pointer: coarse)').matches;
-    selectImagesBtn.addEventListener('click', () => imageInput.click());
-    selectImagesBtn.addEventListener('touchstart', (e) => {
-        e.preventDefault();
-        imageInput.click();
-    });
-    if (!isTouchDevice) {
-        ['dragenter', 'dragover'].forEach(evt => {
-            imageDropArea.addEventListener(evt, (e) => {
-                e.preventDefault();
-                imageDropArea.classList.add('dragover');
-            });
-        });
-        ['dragleave', 'drop'].forEach(evt => {
-            imageDropArea.addEventListener(evt, (e) => {
-                e.preventDefault();
-                imageDropArea.classList.remove('dragover');
-            });
-        });
-        imageDropArea.addEventListener('drop', (e) => {
-            var _a;
-            e.preventDefault();
-            const files = Array.from(((_a = e.dataTransfer) === null || _a === void 0 ? void 0 : _a.files) || []).filter((f) => f.type === 'image/jpeg');
-            if (files.length) {
-                imageFiles = files.map(f => ({ blob: f, name: f.name }));
-                currentImageIndex = 0;
-                renderImageList();
-                openImageEditModal(imageFiles[0]);
+        else {
+            imageFiles = [];
+            currentImageIndex = -1;
+            renderImageList();
+            imageBlock.style.display = 'none';
+            singleUploadBtn.style.display = '';
+            if (files.length > 1) {
+                alert('Можно выбрать несколько файлов только в формате JPEG');
+                fileInput.value = '';
             }
-        });
-    }
-    imageDropArea.addEventListener('click', () => imageInput.click());
+        }
+    });
     uploadImagesBtn.addEventListener('click', () => uploadEditedImages());
 }
 export function renderImageList() {
@@ -92,7 +74,9 @@ export function uploadEditedImages() {
             received.textContent = result.raw_response || '';
             imageFiles = [];
             currentImageIndex = -1;
-            imageInput.value = '';
+            fileInput.value = '';
+            imageBlock.style.display = 'none';
+            singleUploadBtn.style.display = '';
             renderImageList();
             refreshFiles();
             refreshFolderTree();

--- a/src/web_app/static/style.css
+++ b/src/web_app/static/style.css
@@ -60,10 +60,6 @@ button:hover, input[type="submit"]:hover { background-color: var(--color-primary
 #preview-modal .modal__content { width: 80%; height: 80%; max-width: 1000px; max-height: 800px; }
 #preview-frame { width: 100%; height: 100%; border: none; }
 
-#image-drop-area { border: 2px dashed var(--color-primary); padding: var(--spacing-md); text-align: center; margin-top: var(--spacing-md); background: #fafafa; cursor: pointer; }
-#image-drop-area.dragover { background: #e0e0e0; }
-#select-images-btn { padding: 1em 2em; font-size: 1em; }
-#image-files { display: none; }
 #selected-images { list-style: none; padding: 0; margin-top: var(--spacing-md); }
 #selected-images li { margin: var(--spacing-xs) 0; }
 
@@ -100,13 +96,6 @@ button:hover, input[type="submit"]:hover { background-color: var(--color-primary
 }
 
 /* from codex/add-camera-capture-to-image-input */
-@media (pointer: coarse) {
-  #image-drop-area {
-    border: none;
-    padding: 0;
-    background: none;
-  }
-}
 
 /* from main */
 @media (max-width: 600px) {

--- a/src/web_app/templates/index.html
+++ b/src/web_app/templates/index.html
@@ -15,25 +15,22 @@
     <div class="app__container">
         <h1>Загрузка документов</h1>
         <p>Выберите файл и отправьте его на обработку.</p>
-        <form action="/upload" method="post" enctype="multipart/form-data">
-            <input type="file" name="file" accept="image/*,.pdf,.doc,.docx,.txt,.csv,.xls,.xlsx,.ppt,.pptx" capture="environment" />
+        <form action="/upload" method="post" enctype="multipart/form-data" id="upload-form">
+            <input id="file-input" type="file" name="file" multiple
+                   accept="image/*,.pdf,.doc,.docx,.txt,.csv,.xls,.xlsx,.ppt,.pptx" capture="environment" />
             <label for="language">Язык документа:</label>
             <select name="language" id="language">
                 <option value="en">English</option>
                 <option value="ru" selected>Русский</option>
                 <option value="de">Deutsch</option>
             </select>
-            <input type="submit" value="Upload" />
+            <input type="submit" id="single-upload-btn" value="Загрузить" />
         </form>
 
         <progress id="upload-progress" max="100" value="0"></progress>
 
-        <div id="image-upload-block">
-            <h2>Загрузить набор изображений</h2>
-            <div id="image-drop-area">
-                <button id="select-images-btn" type="button">Выбрать фото</button>
-                <input id="image-files" type="file" multiple accept="image/jpeg" capture="environment" />
-            </div>
+        <div id="image-upload-block" style="display: none;">
+            <h2>Выбранные изображения</h2>
             <ul id="selected-images"></ul>
             <button id="upload-images-btn" type="button">Загрузить набор изображений</button>
         </div>

--- a/tests/test_main_js.py
+++ b/tests/test_main_js.py
@@ -95,7 +95,7 @@ def test_main_js_rotate_crop(tmp_path):
           document.dispatchEvent({ type: 'DOMContentLoaded' });
 
           const file = new File(['dummy'], 'test.jpg', { type: 'image/jpeg' });
-          const input = getEl('image-files');
+          const input = getEl('file-input');
           input.files = [file];
           input.dispatchEvent({ type: 'change', target: { files: [file] } });
 

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -342,7 +342,7 @@ def test_root_returns_form_unprotected():
     with LiveClient(app) as client:
         resp = client.get("/")
         assert resp.status_code == 200
-        assert '<form action="/upload" method="post" enctype="multipart/form-data">' in resp.text
+        assert '<form action="/upload" method="post" enctype="multipart/form-data"' in resp.text
         assert 'name="language"' in resp.text
         assert 'id="upload-progress"' in resp.text
         assert 'id="ai-exchange"' in resp.text


### PR DESCRIPTION
## Summary
- streamline upload UI with single file input and optional JPEG batch block
- handle JPEG batches in new imageBatch logic
- adjust tests for updated markup

## Testing
- `npm run build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b47541b36c83309c36dda79bf586ac