### PR TITLE
feat: add cancel button and display AI conversation

### DIFF
--- a/src/web_app/routes/upload.py
+++ b/src/web_app/routes/upload.py
@@ -107,6 +107,8 @@ async def upload_file(
             status="pending",
             missing=missing,
             suggested_path=str(dest_path),
+            prompt=meta_result.get("prompt"),
+            raw_response=meta_result.get("raw_response"),
         )
 
     status = "dry_run" if dry_run else "processed"
@@ -235,6 +237,8 @@ async def upload_images(
             missing=missing,
             sources=sources,
             suggested_path=str(dest_path),
+            prompt=meta_result.get("prompt"),
+            raw_response=meta_result.get("raw_response"),
         )
 
     status = "dry_run" if dry_run else "processed"

--- a/src/web_app/static/dist/imageBatch.js
+++ b/src/web_app/static/dist/imageBatch.js
@@ -10,7 +10,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 import { refreshFiles } from './files.js';
 import { refreshFolderTree } from './folders.js';
 import { openImageEditModal } from './imageEditor.js';
-import { sent, received } from './uploadForm.js';
+import { aiExchange, renderDialog } from './uploadForm.js';
 export let currentImageIndex = -1;
 export let imageFiles = [];
 let fileInput;
@@ -70,8 +70,7 @@ export function uploadEditedImages() {
         const resp = yield fetch('/upload/images', { method: 'POST', body: data });
         if (resp.ok) {
             const result = yield resp.json();
-            sent.textContent = result.prompt || '';
-            received.textContent = result.raw_response || '';
+            renderDialog(aiExchange, result.prompt, result.raw_response);
             imageFiles = [];
             currentImageIndex = -1;
             fileInput.value = '';

--- a/src/web_app/static/dist/uploadForm.js
+++ b/src/web_app/static/dist/uploadForm.js
@@ -9,16 +9,31 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 import { refreshFiles } from './files.js';
 import { refreshFolderTree } from './folders.js';
-export let sent;
-export let received;
+export let aiExchange;
+export function renderDialog(container, prompt, response) {
+    container.innerHTML = '';
+    if (prompt) {
+        const userDiv = document.createElement('div');
+        userDiv.className = 'ai-message user';
+        userDiv.textContent = prompt;
+        container.appendChild(userDiv);
+    }
+    if (response) {
+        const aiDiv = document.createElement('div');
+        aiDiv.className = 'ai-message assistant';
+        aiDiv.textContent = response;
+        container.appendChild(aiDiv);
+    }
+}
 export function setupUploadForm() {
     const form = document.querySelector('form');
     const progress = document.getElementById('upload-progress');
-    sent = document.getElementById('ai-sent');
-    received = document.getElementById('ai-received');
+    aiExchange = document.getElementById('ai-exchange');
     const missingModal = document.getElementById('missing-modal');
     const missingList = document.getElementById('missing-list');
     const missingConfirm = document.getElementById('missing-confirm');
+    const missingCancel = document.getElementById('missing-cancel');
+    const missingDialog = document.getElementById('missing-dialog');
     const suggestedPath = document.getElementById('suggested-path');
     form.addEventListener('submit', (e) => {
         var _a;
@@ -50,6 +65,7 @@ export function setupUploadForm() {
                         li.textContent = path;
                         missingList.appendChild(li);
                     });
+                    renderDialog(missingDialog, result.prompt, result.raw_response);
                     missingModal.style.display = 'flex';
                     missingConfirm.onclick = () => __awaiter(this, void 0, void 0, function* () {
                         try {
@@ -62,8 +78,7 @@ export function setupUploadForm() {
                                 throw new Error();
                             const finalData = yield resp.json();
                             missingModal.style.display = 'none';
-                            sent.textContent = finalData.prompt || '';
-                            received.textContent = finalData.raw_response || '';
+                            renderDialog(aiExchange, finalData.prompt, finalData.raw_response);
                             form.reset();
                             progress.value = 0;
                             refreshFiles();
@@ -73,10 +88,12 @@ export function setupUploadForm() {
                             alert('Ошибка обработки');
                         }
                     });
+                    missingCancel.onclick = () => {
+                        missingModal.style.display = 'none';
+                    };
                 }
                 else {
-                    sent.textContent = result.prompt || '';
-                    received.textContent = result.raw_response || '';
+                    renderDialog(aiExchange, result.prompt, result.raw_response);
                     form.reset();
                     progress.value = 0;
                     refreshFiles();

--- a/src/web_app/static/imageBatch.ts
+++ b/src/web_app/static/imageBatch.ts
@@ -1,7 +1,7 @@
 import { refreshFiles } from './files.js';
 import { refreshFolderTree } from './folders.js';
 import { openImageEditModal } from './imageEditor.js';
-import { sent, received } from './uploadForm.js';
+import { aiExchange, renderDialog } from './uploadForm.js';
 
 export let currentImageIndex = -1;
 export let imageFiles: Array<{ blob: Blob; name: string }> = [];
@@ -65,8 +65,7 @@ export async function uploadEditedImages() {
   const resp = await fetch('/upload/images', { method: 'POST', body: data });
   if (resp.ok) {
     const result = await resp.json();
-    sent.textContent = result.prompt || '';
-    received.textContent = result.raw_response || '';
+    renderDialog(aiExchange, result.prompt, result.raw_response);
     imageFiles = [];
     currentImageIndex = -1;
     fileInput.value = '';

--- a/src/web_app/static/style.css
+++ b/src/web_app/static/style.css
@@ -36,8 +36,25 @@ form { display: flex; flex-direction: column; gap: var(--spacing-md); }
 button, input[type="submit"] { padding: var(--spacing-sm) var(--spacing-md); border: none; background-color: var(--color-primary); color: var(--color-surface); border-radius: 4px; cursor: pointer; }
 button:hover, input[type="submit"]:hover { background-color: var(--color-primary-hover); }
 #upload-progress { width: 100%; margin-top: var(--spacing-md); }
-#ai-exchange { max-height: 200px; overflow-y: auto; font-family: var(--font-mono); background: var(--color-surface-alt); padding: var(--spacing-md); border: 1px solid var(--color-border); margin-top: var(--spacing-md); }
-#ai-exchange pre { white-space: pre-wrap; margin: 0 0 var(--spacing-md) 0; }
+#ai-exchange { margin-top: var(--spacing-md); }
+
+.ai-dialog {
+  max-height: 200px;
+  overflow-y: auto;
+  font-family: var(--font-mono);
+  background: var(--color-surface-alt);
+  padding: var(--spacing-md);
+  border: 1px solid var(--color-border);
+}
+
+.ai-message {
+  margin: var(--spacing-xs) 0;
+  white-space: pre-wrap;
+}
+
+.ai-message.user {
+  font-weight: bold;
+}
 #text-preview {
   font-family: var(--font-mono);
   white-space: pre-wrap;
@@ -57,6 +74,7 @@ button:hover, input[type="submit"]:hover { background-color: var(--color-primary
 #missing-list { list-style: none; padding: 0; margin: var(--spacing-md) 0; }
 #missing-list li { margin: var(--spacing-xs) 0; }
 #suggested-path { word-break: break-all; font-family: var(--font-mono); }
+#missing-dialog { margin-top: var(--spacing-md); }
 #preview-modal .modal__content { width: 80%; height: 80%; max-width: 1000px; max-height: 800px; }
 #preview-frame { width: 100%; height: 100%; border: none; }
 
@@ -90,9 +108,10 @@ button:hover, input[type="submit"]:hover { background-color: var(--color-primary
   max-width: 100%;
 }
 
-#edit-modal .modal__buttons {
+.modal__buttons {
   display: flex;
   gap: var(--spacing-sm);
+  justify-content: flex-end;
 }
 
 /* from codex/add-camera-capture-to-image-input */

--- a/src/web_app/static/uploadForm.ts
+++ b/src/web_app/static/uploadForm.ts
@@ -1,17 +1,37 @@
 import { refreshFiles } from './files.js';
 import { refreshFolderTree } from './folders.js';
 
-export let sent: HTMLElement;
-export let received: HTMLElement;
+export let aiExchange: HTMLElement;
+
+export function renderDialog(
+  container: HTMLElement,
+  prompt?: string,
+  response?: string
+) {
+  container.innerHTML = '';
+  if (prompt) {
+    const userDiv = document.createElement('div');
+    userDiv.className = 'ai-message user';
+    userDiv.textContent = prompt;
+    container.appendChild(userDiv);
+  }
+  if (response) {
+    const aiDiv = document.createElement('div');
+    aiDiv.className = 'ai-message assistant';
+    aiDiv.textContent = response;
+    container.appendChild(aiDiv);
+  }
+}
 
 export function setupUploadForm() {
   const form = document.querySelector('form') as HTMLFormElement;
   const progress = document.getElementById('upload-progress') as HTMLProgressElement;
-  sent = document.getElementById('ai-sent')!;
-  received = document.getElementById('ai-received')!;
+  aiExchange = document.getElementById('ai-exchange')!;
   const missingModal = document.getElementById('missing-modal')!;
   const missingList = document.getElementById('missing-list')!;
   const missingConfirm = document.getElementById('missing-confirm')!;
+  const missingCancel = document.getElementById('missing-cancel')!;
+  const missingDialog = document.getElementById('missing-dialog')!;
   const suggestedPath = document.getElementById('suggested-path')!;
 
   form.addEventListener('submit', (e) => {
@@ -43,6 +63,7 @@ export function setupUploadForm() {
             li.textContent = path;
             missingList.appendChild(li);
           });
+          renderDialog(missingDialog, result.prompt, result.raw_response);
           missingModal.style.display = 'flex';
           missingConfirm.onclick = async () => {
             try {
@@ -54,8 +75,7 @@ export function setupUploadForm() {
               if (!resp.ok) throw new Error();
               const finalData = await resp.json();
               missingModal.style.display = 'none';
-              sent.textContent = finalData.prompt || '';
-              received.textContent = finalData.raw_response || '';
+              renderDialog(aiExchange, finalData.prompt, finalData.raw_response);
               form.reset();
               progress.value = 0;
               refreshFiles();
@@ -64,9 +84,11 @@ export function setupUploadForm() {
               alert('Ошибка обработки');
             }
           };
+          missingCancel.onclick = () => {
+            missingModal.style.display = 'none';
+          };
         } else {
-          sent.textContent = result.prompt || '';
-          received.textContent = result.raw_response || '';
+          renderDialog(aiExchange, result.prompt, result.raw_response);
           form.reset();
           progress.value = 0;
           refreshFiles();

--- a/src/web_app/templates/index.html
+++ b/src/web_app/templates/index.html
@@ -70,12 +70,7 @@
         </table>
         <div id="text-preview"></div>
 
-        <div id="ai-exchange">
-            <h3>Отправлено</h3>
-            <pre id="ai-sent"></pre>
-            <h3>Получено</h3>
-            <pre id="ai-received"></pre>
-        </div>
+        <div id="ai-exchange" class="ai-dialog"></div>
     </div>
 
     <div id="edit-modal" class="modal" role="dialog" aria-modal="true">
@@ -114,7 +109,11 @@
             <h3>Создать недостающие папки?</h3>
             <p id="suggested-path"></p>
             <ul id="missing-list"></ul>
-            <button id="missing-confirm">Продолжить</button>
+            <div id="missing-dialog" class="ai-dialog"></div>
+            <div class="modal__buttons">
+                <button id="missing-confirm">Продолжить</button>
+                <button id="missing-cancel" type="button">Отменить</button>
+            </div>
         </div>
     </div>
 


### PR DESCRIPTION
## Summary
- add cancel option and AI dialog to missing folder modal
- format AI conversations and show them on uploads
- include prompt data in pending upload responses

## Testing
- `npm run build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b47a3968bc83308b35d12c2f6bc13d