### PR TITLE
feat: normalize person names

### DIFF
--- a/src/file_sorter.py
+++ b/src/file_sorter.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Tuple, Callable
 
 from config import GENERAL_FOLDER_NAME
+from utils.names import normalize_person_name
 
 try:
     from unidecode import unidecode
@@ -126,7 +127,7 @@ def place_file(
     missing: List[str] = []
 
     # Сначала person (или общий)
-    person = metadata.get("person")
+    person = normalize_person_name(metadata.get("person"))
     if not person or not str(person).strip():
         person = GENERAL_FOLDER_NAME
     metadata["person"] = person
@@ -134,13 +135,15 @@ def place_file(
     if not dest_dir.exists():
         missing.append(str(dest_dir.relative_to(base_dir)))
 
-    # Затем category/subcategory
+    # Затем category/subcategory, игнорируя совпадения с person
     for key in ("category", "subcategory"):
         value = metadata.get(key)
-        if value:
+        if value and str(value).strip().lower() != str(person).strip().lower():
             dest_dir /= str(value)
             if not dest_dir.exists():
                 missing.append(str(dest_dir.relative_to(base_dir)))
+        else:
+            metadata[key] = None
 
     # Затем issuer (если есть)
     issuer = metadata.get("issuer")

--- a/src/metadata_generation.py
+++ b/src/metadata_generation.py
@@ -31,6 +31,7 @@ from config import (
 
 from services.openrouter import OpenRouterError
 from file_utils.mrz import parse_mrz
+from utils.names import normalize_person_name
 
 
 MILITARY_DATE_PATTERN = re.compile(
@@ -298,6 +299,9 @@ async def generate_metadata(
         parsed_person = _parse_person_from_text(text)
         if parsed_person:
             defaults["person"] = parsed_person
+
+    if defaults.get("person"):
+        defaults["person"] = normalize_person_name(defaults["person"])
 
     # Единый список тегов без дублей
     tag_values = []

--- a/src/prompt_templates.py
+++ b/src/prompt_templates.py
@@ -31,5 +31,6 @@ def build_metadata_prompt(
         "Return a JSON object with the fields: category, subcategory, needs_new_folder (boolean), issuer, person, doc_type, "
         "date, amount, counterparty, document_number, due_date, currency, tags_ru (list of strings), tags_en (list of strings), "
         "suggested_filename, description.\n"
+        "Field 'person' must be in the format 'Фамилия Имя Отчество'; do not use the person's name in category or subcategory.\n"
         f"Document text:\n{text}"
     )

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,0 +1,2 @@
+"""Various utility helpers for DocRouter."""
+

--- a/src/utils/names.py
+++ b/src/utils/names.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+# Грубый список окончаний фамилий для распознавания
+_SURNAME_ENDINGS = (
+    "ов",
+    "ова",
+    "ев",
+    "ева",
+    "ёв",
+    "ёва",
+    "ин",
+    "ина",
+    "ын",
+    "ына",
+    "ий",
+    "ый",
+    "ая",
+    "ко",
+    "юк",
+    "ич",
+    "енко",
+    "ский",
+    "ская",
+    "цкий",
+    "цкая",
+)
+
+
+_NAME_SPLIT_RE = re.compile(r"[\s,]+")
+
+
+def _looks_like_surname(part: str) -> bool:
+    lower = part.lower()
+    return any(lower.endswith(end) for end in _SURNAME_ENDINGS)
+
+
+def normalize_person_name(name: Optional[str]) -> Optional[str]:
+    """Привести ФИО к формату ``Фамилия Имя Отчество``.
+
+    - Удаляет лишние запятые и пробелы.
+    - Убирает повторяющиеся части.
+    - Преобразует ``Имя Фамилия`` в ``Фамилия Имя`` при необходимости.
+    - Каждую часть приводит к виду ``Title Case`` (поддерживает дефис).
+    """
+    if not name:
+        return name
+
+    parts = [p for p in _NAME_SPLIT_RE.split(name.strip()) if p]
+    if not parts:
+        return None
+
+    # Удаляем дубли (регистр не важен)
+    seen = set()
+    unique_parts = []
+    for part in parts:
+        key = part.lower()
+        if key not in seen:
+            seen.add(key)
+            unique_parts.append(part)
+    parts = unique_parts
+
+    if len(parts) == 2:
+        first_surname = _looks_like_surname(parts[0])
+        second_surname = _looks_like_surname(parts[1])
+        if second_surname and not first_surname:
+            parts = [parts[1], parts[0]]
+    elif len(parts) == 3:
+        if _looks_like_surname(parts[1]) and not _looks_like_surname(parts[0]):
+            parts = [parts[1], parts[0], parts[2]]
+
+    def _norm_word(word: str) -> str:
+        return "-".join(w.capitalize() for w in word.split("-"))
+
+    parts = [_norm_word(p) for p in parts]
+    return " ".join(parts)
+
+
+__all__ = ["normalize_person_name"]

--- a/tests/test_file_sorter.py
+++ b/tests/test_file_sorter.py
@@ -92,6 +92,25 @@ def test_place_file_uses_person_from_metadata(tmp_path):
     ]
 
 
+def test_place_file_ignores_person_in_category(tmp_path):
+    src = tmp_path / "input.pdf"
+    src.write_text("data")
+
+    dest_root = tmp_path / "Archive"
+    metadata = sample_metadata()
+    metadata["person"] = "Иванов Иван"
+    metadata["category"] = "Иванов Иван"
+    metadata["subcategory"] = "Иванов Иван"
+    dest, missing, _ = place_file(src, metadata, dest_root, dry_run=True)
+
+    expected = dest_root / "Иванов Иван" / "Sparkasse" / "2023-10-12__Kreditvertrag.pdf"
+    assert dest == expected
+    assert missing == [
+        "Иванов Иван",
+        "Иванов Иван/Sparkasse",
+    ]
+
+
 def test_place_file_uses_general_when_person_empty(tmp_path):
     src = tmp_path / "input.pdf"
     src.write_text("data")

--- a/tests/test_metadata_generation.py
+++ b/tests/test_metadata_generation.py
@@ -149,7 +149,7 @@ def test_multilanguage_tags_parsing(monkeypatch):
         "Подкатегория",
         "Тип",
         "Организация",
-        "Иван Иванов",
+        "Иванов Иван",
     }
     assert expected.issubset(set(meta.tags))
 
@@ -161,7 +161,7 @@ def test_generate_metadata_parses_mrz():
     )
     result = asyncio.run(generate_metadata(text, analyzer=DummyAnalyzer()))
     meta = result["metadata"]
-    assert meta.person == "ANNA MARIA ERIKSSON"
+    assert meta.person == "Anna Maria Eriksson"
     assert meta.date_of_birth == "1974-08-12"
     assert meta.expiration_date == "2012-04-15"
     assert meta.passport_number == "L898902C3"

--- a/tests/test_utils_names.py
+++ b/tests/test_utils_names.py
@@ -1,0 +1,11 @@
+from utils.names import normalize_person_name
+
+
+def test_normalizes_commas_and_order():
+    assert normalize_person_name("Иван Иванов") == "Иванов Иван"
+    assert normalize_person_name("иванов, иван, иванович") == "Иванов Иван Иванович"
+
+
+def test_removes_duplicates():
+    raw = "Иванов Иван Иванович, Иванов Иван Иванович"
+    assert normalize_person_name(raw) == "Иванов Иван Иванович"


### PR DESCRIPTION
## Summary
- add utility to normalize person names
- normalize person metadata during generation and file placement
- instruct LLM to return person as `Фамилия Имя Отчество`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b48181645483308427e5e33befb8db