### PR TITLE
feat: reuse existing folders

### DIFF
--- a/src/prompt_templates.py
+++ b/src/prompt_templates.py
@@ -8,10 +8,12 @@ def build_metadata_prompt(
     text: str,
     *,
     folder_tree: Optional[Dict[str, Any]] = None,
+    folder_index: Optional[Dict[str, Any]] = None,
     file_info: Optional[Dict[str, Any]] = None,
 ) -> str:
     """Сформировать промт для извлечения метаданных."""
     tree_json = json.dumps(folder_tree or {}, ensure_ascii=False)
+    index_json = json.dumps(folder_index or {}, ensure_ascii=False)
     info = file_info or {}
     filename = info.get("name")
     extension = info.get("extension")
@@ -27,10 +29,17 @@ def build_metadata_prompt(
         "Possible document types include: contracts, receipts, notifications, advertisement.\n"
         "Existing folder tree (JSON):\n"
         f"{tree_json}\n"
-        "Если ни одна папка не подходит, предложи новую category/subcategory.\n"
+        "Existing folders index (JSON):\n"
+        f"{index_json}\n"
+        "Если ни одна папка не подходит, предложи новую category/subcategory. \n"
+        "Выбирай person/category строго из Existing folders index, если совпадение найдено; needs_new_folder=true только при полном отсутствии.\n"
         "Return a JSON object with the fields: category, subcategory, needs_new_folder (boolean), issuer, person, doc_type, "
-        "date, amount, counterparty, document_number, due_date, currency, tags_ru (list of strings), tags_en (list of strings), "
+        "date, amount, counterparty, document_number, due_date, currency, tags_ru (list of strings), tags_en (list of strings),"
         "suggested_filename, description.\n"
         "Field 'person' must be in the format 'Фамилия Имя Отчество'; do not use the person's name in category or subcategory.\n"
         f"Document text:\n{text}"
     )
+
+
+__all__ = ["build_metadata_prompt"]
+

--- a/src/web_app/routes/folders.py
+++ b/src/web_app/routes/folders.py
@@ -20,5 +20,6 @@ def _resolve_in_output(relative: str) -> Path:
 @router.get("/folder-tree")
 async def folder_tree():
     """Вернуть структуру папок в выходном каталоге."""
-    return get_folder_tree(server.config.output_dir)
+    tree, _ = get_folder_tree(server.config.output_dir)
+    return tree
 

--- a/src/web_app/routes/upload.py
+++ b/src/web_app/routes/upload.py
@@ -49,10 +49,10 @@ async def upload_file(
         )
         lang_ocr = LANG_MAP.get(lang_display, lang_display)
         text = server.extract_text(temp_path, language=lang_ocr)
-        folder_tree = get_folder_tree(server.config.output_dir)
+        folder_tree, folder_index = get_folder_tree(server.config.output_dir)
         try:
             meta_result = await server.metadata_generation.generate_metadata(
-                text, folder_tree=folder_tree
+                text, folder_tree=folder_tree, folder_index=folder_index
             )
         except OpenRouterError as exc:
             logger.exception("Metadata generation failed for %s", file.filename)
@@ -180,10 +180,10 @@ async def upload_images(
         )
         lang_ocr = LANG_MAP.get(lang_display, lang_display)
         text = server.extract_text(pdf_path, language=lang_ocr)
-        folder_tree = get_folder_tree(server.config.output_dir)
+        folder_tree, folder_index = get_folder_tree(server.config.output_dir)
         try:
             meta_result = await server.metadata_generation.generate_metadata(
-                text, folder_tree=folder_tree
+                text, folder_tree=folder_tree, folder_index=folder_index
             )
         except OpenRouterError as exc:
             logger.exception("Metadata generation failed for images")

--- a/tests/metadata_generation/test_military_id.py
+++ b/tests/metadata_generation/test_military_id.py
@@ -9,6 +9,7 @@ class DummyAnalyzer(MetadataAnalyzer):
         self,
         text: str,
         folder_tree: Dict[str, Any] | None = None,
+        folder_index: Dict[str, Any] | None = None,
         file_info: Dict[str, Any] | None = None,
     ) -> Dict[str, Any]:
         return {"prompt": None, "raw_response": None, "metadata": {}}

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -62,7 +62,12 @@ class LiveClient:
         return self.session.delete(self.base_url + path, **kwargs)
 
 
-async def _mock_generate_metadata(text: str, folder_tree=None):
+async def _mock_generate_metadata(
+    text: str,
+    folder_tree=None,
+    folder_index=None,
+    file_info=None,
+):
     """Детерминированные метаданные для стабильных проверок."""
     meta = Metadata(
         person="John Doe",
@@ -377,7 +382,7 @@ def test_upload_pending_then_finalize(tmp_path, monkeypatch):
         with open(path, "r", encoding="utf-8") as f:
             return f.read()
 
-    async def _metadata_pending(text: str, folder_tree=None):
+    async def _metadata_pending(text: str, folder_tree=None, folder_index=None, file_info=None):
         meta = Metadata(
             category="Финансы",
             subcategory="Банки",


### PR DESCRIPTION
## Summary
- build folder index and expose along with folder tree
- include index in LLM prompt and reuse existing folder names
- add tests for folder index matching

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b483362fac833080e9e7061ff2aad0