### PR TITLE
feat: cache directory scan

### DIFF
--- a/tests/test_files_scan_cache.py
+++ b/tests/test_files_scan_cache.py
@@ -1,0 +1,28 @@
+import os
+import asyncio
+
+os.environ["DB_URL"] = ":memory:"
+
+from web_app import server  # noqa: E402
+from web_app.routes import files as files_module  # noqa: E402
+
+
+def test_list_files_uses_cache(monkeypatch, tmp_path):
+    files_module._last_scan_time = 0
+    files_module._last_upload_mtime = 0
+    server.config.output_dir = str(tmp_path)
+    upload_dir = tmp_path / "uploads"
+    upload_dir.mkdir()
+    monkeypatch.setattr(files_module, "UPLOAD_DIR", upload_dir)
+
+    calls = {"n": 0}
+
+    def fake_scan():
+        calls["n"] += 1
+
+    monkeypatch.setattr(files_module, "_scan_output_dir", fake_scan)
+
+    asyncio.run(files_module.list_files())
+    asyncio.run(files_module.list_files())
+
+    assert calls["n"] == 1


### PR DESCRIPTION
## Summary
- avoid rescanning output directory on each `/files` request by caching results
- test that repeated `/files` calls without changes do not trigger a rescan

## Testing
- `pytest tests/test_files_scan_cache.py::test_list_files_uses_cache -q`

------
https://chatgpt.com/codex/tasks/task_e_68b4875f1c308330a8c8e7986270db89