### PR TITLE
Hash files by content and update DB on rename

### DIFF
--- a/src/web_app/db.py
+++ b/src/web_app/db.py
@@ -58,6 +58,9 @@ def init_db() -> None:
             )
             """
         )
+        _conn.execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_files_id ON files(id)"
+        )
 
 
 def _serialize_record(record: FileRecord) -> Dict[str, Any]:

--- a/src/web_app/routes/files.py
+++ b/src/web_app/routes/files.py
@@ -70,7 +70,7 @@ def _scan_output_dir() -> None:
             except Exception:  # pragma: no cover
                 logger.warning("Failed to load metadata for %s", file_path)
 
-        file_id = hashlib.sha1(str(file_path).encode("utf-8")).hexdigest()
+        file_id = hashlib.sha1(file_path.read_bytes()).hexdigest()
         database.add_file(file_id, file_path.name, metadata, str(file_path), "processed")
         existing_records[file_path] = file_id
         existing_paths.add(file_path)

--- a/tests/test_scan_output_dir.py
+++ b/tests/test_scan_output_dir.py
@@ -1,0 +1,37 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+from web_app import server
+from web_app.routes.files import _scan_output_dir
+
+
+def test_scan_output_dir_updates_on_rename(tmp_path, monkeypatch):
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+
+    db_path = tmp_path / "db.sqlite"
+    monkeypatch.setattr(server.database, "_DB_PATH", db_path)
+    server.database.init_db()
+
+    server.config.output_dir = str(out_dir)
+
+    file = out_dir / "doc.txt"
+    file.write_text("content")
+
+    _scan_output_dir()
+    records = server.database.list_files()
+    assert len(records) == 1
+    file_id = records[0].id
+
+    new_path = out_dir / "renamed.txt"
+    file.rename(new_path)
+
+    _scan_output_dir()
+    records = server.database.list_files()
+    assert len(records) == 1
+    record = records[0]
+    assert record.id == file_id
+    assert record.path == str(new_path)


### PR DESCRIPTION
## Summary
- Use file content hash in `_scan_output_dir` to keep IDs stable across renames
- Add unique index on `files.id` to avoid duplicate records
- Test that renaming a file updates its database record instead of creating a duplicate

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4875a7adc833090906e242656c762