### PR TITLE
Install additional system libraries for Tesseract, magic and OpenCV

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,12 @@ FROM python:3.11-slim
 RUN apt-get update && apt-get install -y --no-install-recommends \
     tesseract-ocr \
     tesseract-ocr-rus \
+    libmagic1 \
+    libglib2.0-0 \
+    libgl1 \
+    ffmpeg \
+    libsm6 \
+    libxext6 \
     && rm -rf /var/lib/apt/lists/*
 
 # Ensure Tesseract can locate language data


### PR DESCRIPTION
## Summary
- add libmagic, glib, GL, ffmpeg and X libs to base image for Tesseract & OpenCV

## Testing
- `pytest`
- `docker --version` *(fails: command not found)*
- `apt-get update` *(fails: repository InRelease is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b48a94f9848330ac27c04c56141918