### PR TITLE
Add non-root application user in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,10 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
+RUN useradd -m app && chown -R app /app
+
 EXPOSE 8000
+
+USER app
 
 CMD ["python", "main.py"]


### PR DESCRIPTION
## Summary
- add `app` user and set ownership of /app
- run container as non-root user

## Testing
- `pytest`
- ⚠️ `docker build -t docrouter-test .` (docker not installed)


------
https://chatgpt.com/codex/tasks/task_e_68b48abfe0f88330857a7a93eeef438c