### PR TITLE
chore: ignore node_modules in docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,3 +8,4 @@ logs/
 uploads/
 sorted/
 tests/
+node_modules/


### PR DESCRIPTION
## Summary
- ignore node_modules in Docker builds

## Testing
- `pytest -q`
- `docker build -t docrouter:latest .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b48a9f53088330aca5cc1b18c3f819