### PR TITLE
Handle non-dict metadata in metadata generation

### DIFF
--- a/src/metadata_generation.py
+++ b/src/metadata_generation.py
@@ -256,7 +256,10 @@ async def generate_metadata(
     result = await analyzer.analyze(
         text, folder_tree=folder_tree, folder_index=folder_index, file_info=file_info
     )
-    metadata = result.get("metadata", {})
+    metadata = result.get("metadata") or {}
+    if not isinstance(metadata, dict):
+        logger.error("Metadata should be a dict, got %s", type(metadata).__name__)
+        metadata = {}
 
     defaults = {
         "category": None,
@@ -279,8 +282,8 @@ async def generate_metadata(
         "suggested_filename": None,
         "description": None,
         "needs_new_folder": False,
-    } 
-    defaults.update(metadata or {})
+    }
+    defaults.update(metadata)
 
     if not defaults.get("date"):
         military_date = parse_military_id_date(text)

--- a/tests/test_metadata_generation.py
+++ b/tests/test_metadata_generation.py
@@ -249,3 +249,21 @@ def test_folder_index_reuses_existing_folder(tmp_path):
     assert meta.person == "BONCH-OSMOLOVSKAIA, Natalia"
     assert meta.category == "Taxes"
     assert meta.needs_new_folder is False
+
+
+class InvalidAnalyzer(MetadataAnalyzer):
+    async def analyze(
+        self,
+        text: str,
+        folder_tree: Dict[str, Any] | None = None,
+        folder_index: Dict[str, Any] | None = None,
+        file_info: Dict[str, Any] | None = None,
+    ) -> Dict[str, Any]:
+        return {"prompt": None, "raw_response": None, "metadata": ["not", "a", "dict"]}
+
+
+def test_generate_metadata_handles_invalid_metadata():
+    result = asyncio.run(generate_metadata("text", analyzer=InvalidAnalyzer()))
+    meta: Metadata = result["metadata"]
+    assert meta.category is None
+    assert meta.tags == []


### PR DESCRIPTION
## Summary
- avoid crashing when metadata analyzer returns non-dict values
- add regression test for invalid metadata

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b490bbefdc8330b3bde1b8c6972867