### PR TITLE
Handle list metadata in generation

### DIFF
--- a/src/metadata_generation.py
+++ b/src/metadata_generation.py
@@ -257,7 +257,17 @@ async def generate_metadata(
         text, folder_tree=folder_tree, folder_index=folder_index, file_info=file_info
     )
     metadata = result.get("metadata") or {}
-    if not isinstance(metadata, dict):
+
+    if isinstance(metadata, list):
+        if metadata and isinstance(metadata[0], dict):
+            metadata = metadata[0]
+        else:
+            logger.error(
+                "Metadata should be a dict or list of dicts, got list of %s",
+                ",".join(type(item).__name__ for item in metadata) if metadata else "<empty>",
+            )
+            metadata = {}
+    elif not isinstance(metadata, dict):
         logger.error("Metadata should be a dict, got %s", type(metadata).__name__)
         metadata = {}
 

--- a/tests/test_metadata_generation.py
+++ b/tests/test_metadata_generation.py
@@ -267,3 +267,25 @@ def test_generate_metadata_handles_invalid_metadata():
     meta: Metadata = result["metadata"]
     assert meta.category is None
     assert meta.tags == []
+
+
+class ListAnalyzer(MetadataAnalyzer):
+    async def analyze(
+        self,
+        text: str,
+        folder_tree: Dict[str, Any] | None = None,
+        folder_index: Dict[str, Any] | None = None,
+        file_info: Dict[str, Any] | None = None,
+    ) -> Dict[str, Any]:
+        return {
+            "prompt": None,
+            "raw_response": None,
+            "metadata": [{"category": "Health", "tags": ["a"]}],
+        }
+
+
+def test_generate_metadata_accepts_list_of_dicts():
+    result = asyncio.run(generate_metadata("text", analyzer=ListAnalyzer()))
+    meta: Metadata = result["metadata"]
+    assert meta.category == "Health"
+    assert set(meta.tags) == {"a", "Health"}


### PR DESCRIPTION
## Summary
- allow metadata generator to process list responses by taking first dict
- test metadata generation with list

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b492e7c39483308c2590b5f08f182e