### PR TITLE
Avoid expensive chown during Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,9 +20,11 @@ WORKDIR /app
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY . .
+# Create a non-root user ahead of time to avoid expensive chown operations
+RUN useradd -m app
 
-RUN useradd -m app && chown -R app /app
+# Copy source code and assign ownership in one step
+COPY --chown=app:app . .
 
 EXPOSE 8000
 


### PR DESCRIPTION
## Summary
- create non-root user before copying source
- copy files with proper ownership to skip costly `chown -R`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b496367b4c833098ec58ac4ba993a0