### PR TITLE
fix: close temporary file before saving PDF page

### DIFF
--- a/src/file_utils/__init__.py
+++ b/src/file_utils/__init__.py
@@ -115,13 +115,15 @@ def extract_text_pdf(path: Path, language: str = "eng") -> str:
                 )
 
             pix = page.get_pixmap()
+
+            # На Windows невозможно перезаписать открытый временный файл,
+            # поэтому сначала закрываем его, а затем сохраняем изображение.
             tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".png")
+            tmp_path = Path(tmp.name)
+            tmp.close()
+
             try:
-                pix.save(tmp.name)
-                tmp_path = Path(tmp.name)
-            finally:
-                tmp.close()
-            try:
+                pix.save(tmp_path)
                 ocr_text = extract_text_image(tmp_path, language=language)
             finally:
                 tmp_path.unlink(missing_ok=True)


### PR DESCRIPTION
## Summary
- close NamedTemporaryFile before saving PyMuPDF pixmap to avoid Windows permission errors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdcab5713883309527a8d2e361bd87