### PR TITLE
feat: pending confirmation for new folders

### DIFF
--- a/src/web_app/routes/upload.py
+++ b/src/web_app/routes/upload.py
@@ -82,6 +82,7 @@ async def upload_file(
             server.config.output_dir,
             dry_run=dry_run,
             needs_new_folder=metadata.needs_new_folder,
+            confirm_callback=lambda _paths: False,
         )
         metadata = Metadata(**meta_dict)
 
@@ -212,6 +213,7 @@ async def upload_images(
             server.config.output_dir,
             dry_run=dry_run,
             needs_new_folder=metadata.needs_new_folder,
+            confirm_callback=lambda _paths: False,
         )
         metadata = Metadata(**meta_dict)
     except HTTPException:

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -11,6 +11,7 @@ from file_utils import extract_text, UnsupportedFileType
 from docrouter import process_directory
 import metadata_generation
 from models import Metadata
+from web_app import db as database
 
 
 def test_extract_text_logs_error_for_unknown_extension(tmp_path, caplog):
@@ -34,10 +35,11 @@ def test_process_directory_logs(tmp_path, monkeypatch, caplog):
     monkeypatch.setattr(metadata_generation, "generate_metadata", fake_generate)
 
     dest_root = tmp_path / "Archive"
+    database.init_db()
 
     with caplog.at_level(logging.INFO):
         asyncio.run(process_directory(input_dir, dest_root))
 
     assert f"Processing directory {input_dir}" in caplog.text
     assert f"Processing file {file_path}" in caplog.text
-    assert f"Finished processing {file_path}" in caplog.text
+    assert f"Pending {file_path} due to missing" in caplog.text


### PR DESCRIPTION
## Summary
- handle missing-folder confirmation in `docrouter` and upload routes
- add callback support and pending status persistence in DB
- refine file sorter confirmation API

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bdcd95244c8330a9f2927c925df94b