### PR TITLE
feat: add finalize endpoint

### DIFF
--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -443,7 +443,10 @@ def test_upload_pending_then_finalize(tmp_path, monkeypatch):
         ]
         file_id = data["id"]
 
-        resp_final = client.post(f"/files/{file_id}/finalize")
+        resp_final = client.post(
+            f"/files/{file_id}/finalize",
+            json={"missing": data["missing"], "confirm": True},
+        )
         assert resp_final.status_code == 200
         final_data = resp_final.json()
         assert final_data["status"] == "processed"


### PR DESCRIPTION
## Summary
- add finalize endpoint with confirmation handling
- adjust web tests for new finalize API

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bdcf1fc724833096768da61be1990f