### PR TITLE
feat: add review status and dry-run uploads

### DIFF
--- a/src/file_sorter.py
+++ b/src/file_sorter.py
@@ -263,3 +263,26 @@ def place_file(
     logger.debug("Wrote metadata to %s", json_file)
 
     return dest_file, missing, confirmed
+
+
+def preview_destination(
+    src_path: str | Path,
+    metadata: Dict[str, Any],
+    dest_root: str | Path,
+    needs_new_folder: bool = False,
+) -> Tuple[Path, List[str]]:
+    """Рассчитать путь назначения без перемещения файла.
+
+    Это удобная обёртка над :func:`place_file` с ``dry_run=True``.
+    Возвращает путь к предполагаемому файлу и список недостающих каталогов.
+    """
+
+    dest, missing, _ = place_file(
+        src_path,
+        metadata,
+        dest_root,
+        dry_run=True,
+        needs_new_folder=needs_new_folder,
+        confirm_callback=None,
+    )
+    return dest, missing

--- a/src/models.py
+++ b/src/models.py
@@ -44,7 +44,7 @@ class FileRecord(BaseModel):
     expiration_date: Optional[str] = None
     passport_number: Optional[str] = None
     path: str
-    status: str
+    status: str = "review"
     prompt: Any | None = None
     raw_response: Any | None = None
     missing: List[str] = Field(default_factory=list)
@@ -55,6 +55,7 @@ class FileRecord(BaseModel):
     suggested_path: Optional[str] = None
     created_path: Optional[str] = None
     confirmed: bool = False
+    review_comment: Optional[str] = None
 
 
 class UploadResponse(BaseModel):

--- a/src/web_app/db.py
+++ b/src/web_app/db.py
@@ -44,7 +44,7 @@ def init_db() -> None:
                 expiration_date TEXT,
                 passport_number TEXT,
                 path TEXT NOT NULL,
-                status TEXT NOT NULL,
+                status TEXT NOT NULL DEFAULT 'review',
                 prompt TEXT,
                 raw_response TEXT,
                 missing TEXT,
@@ -54,7 +54,8 @@ def init_db() -> None:
                 sources TEXT,
                 suggested_path TEXT,
                 created_path TEXT,
-                confirmed INTEGER
+                confirmed INTEGER,
+                review_comment TEXT
             )
             """
         )
@@ -86,6 +87,7 @@ def _serialize_record(record: FileRecord) -> Dict[str, Any]:
         "suggested_path": record.suggested_path,
         "created_path": record.created_path,
         "confirmed": 1 if record.confirmed else 0,
+        "review_comment": record.review_comment,
     }
 
 
@@ -113,6 +115,7 @@ def _row_to_record(row: sqlite3.Row) -> FileRecord:
         suggested_path=row["suggested_path"],
         created_path=row["created_path"],
         confirmed=bool(row["confirmed"]),
+        review_comment=row["review_comment"],
     )
 
 
@@ -133,7 +136,7 @@ def add_file(
     filename: str,
     metadata: Metadata,
     path: str,
-    status: str,
+    status: str = "review",
     prompt: Any | None = None,
     raw_response: Any | None = None,
     missing: Optional[List[str]] = None,
@@ -143,6 +146,7 @@ def add_file(
     suggested_path: str | None = None,
     confirmed: bool = False,
     created_path: str | None = None,
+    review_comment: str | None = None,
 ) -> None:
     record = FileRecord(
         id=file_id,
@@ -166,6 +170,7 @@ def add_file(
         suggested_path=suggested_path,
         created_path=created_path,
         confirmed=confirmed,
+        review_comment=review_comment,
     )
     _upsert(record)
 
@@ -196,6 +201,7 @@ def update_file(
     suggested_path: str | None = None,
     confirmed: bool | None = None,
     created_path: str | None = None,
+    review_comment: str | None = None,
 ) -> None:
     record = get_file(file_id)
     if record is None:
@@ -230,6 +236,8 @@ def update_file(
         record.confirmed = confirmed
     if created_path is not None:
         record.created_path = created_path
+    if review_comment is not None:
+        record.review_comment = review_comment
     _upsert(record)
 
 

--- a/src/web_app/routes/files.py
+++ b/src/web_app/routes/files.py
@@ -284,7 +284,7 @@ async def finalize_file(file_id: str, data: dict = Body(...)):
     if not record:
         raise HTTPException(status_code=404, detail="File not found")
 
-    if record.status != "pending":
+    if record.status not in {"pending", "review"}:
         return record
 
     missing = data.get("missing") or []


### PR DESCRIPTION
## Summary
- сохраняем путь и недостающие каталоги при загрузке, помечая записи статусом `review`
- добавлен столбец `review_comment` и значение по умолчанию для `status`
- добавлен режим предварительного расчёта пути без перемещения файла

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bdd33c7d6883309dbc78c34e57e413