### PR TITLE
feat(web): add review page and client actions

### DIFF
--- a/src/web_app/static/js/review.js
+++ b/src/web_app/static/js/review.js
@@ -1,0 +1,80 @@
+import { renderDialog } from '../dist/uploadForm.js';
+
+function getFileId() {
+  const params = new URLSearchParams(window.location.search);
+  return params.get('id');
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const id = getFileId();
+  if (!id) {
+    return;
+  }
+
+  const suggestedPathEl = document.getElementById('suggested-path');
+  const missingListEl = document.getElementById('missing-list');
+  const commentEl = document.getElementById('comment');
+  const dialogEl = document.getElementById('review-dialog');
+  const confirmBtn = document.getElementById('confirm-btn');
+  const commentBtn = document.getElementById('comment-btn');
+
+  async function loadDetails() {
+    try {
+      const resp = await fetch(`/files/${id}/details`);
+      if (!resp.ok) return;
+      const data = await resp.json();
+      if (suggestedPathEl) {
+        suggestedPathEl.textContent = data.suggested_path || '';
+      }
+      if (missingListEl) {
+        missingListEl.innerHTML = '';
+        (data.missing || []).forEach((path) => {
+          const li = document.createElement('li');
+          li.textContent = path;
+          missingListEl.appendChild(li);
+        });
+      }
+      if (dialogEl) {
+        renderDialog(dialogEl, data.prompt, data.raw_response);
+      }
+    } catch {
+      // ignore
+    }
+  }
+
+  confirmBtn?.addEventListener('click', async () => {
+    try {
+      await fetch(`/files/${id}/confirm`, { method: 'POST' });
+      await fetch('/files?force=1');
+      if (window.opener) {
+        window.opener.location.reload();
+      }
+    } catch {
+      // ignore
+    }
+  });
+
+  commentBtn?.addEventListener('click', async () => {
+    const comment = commentEl?.value.trim();
+    if (!comment) return;
+    try {
+      const resp = await fetch(`/files/${id}/comment`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ comment }),
+      });
+      if (!resp.ok) return;
+      const data = await resp.json();
+      if (dialogEl) {
+        renderDialog(dialogEl, data.prompt, data.raw_response);
+      }
+      if (commentEl) {
+        commentEl.value = '';
+      }
+    } catch {
+      // ignore
+    }
+  });
+
+  loadDetails();
+});

--- a/src/web_app/templates/review.html
+++ b/src/web_app/templates/review.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>DocRouter – Проверка файла</title>
+    <link rel="stylesheet" href="/static/style.css">
+    <script type="module" src="/static/js/review.js"></script>
+</head>
+<body class="app">
+    <div class="app__container">
+        <h1>Проверка файла</h1>
+        <p>Предлагаемый путь: <span id="suggested-path"></span></p>
+        <ul id="missing-list"></ul>
+        <textarea id="comment" placeholder="Комментарий"></textarea>
+        <div id="review-dialog" class="ai-dialog"></div>
+        <div class="review__buttons">
+            <button id="confirm-btn" type="button">Подтвердить</button>
+            <button id="comment-btn" type="button">Отправить комментарий</button>
+        </div>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add review page template showing suggested path, missing folders, and comment box
- Implement review.js to confirm file placement and send comments to AI, refreshing dialog and file list

## Testing
- `npm run build`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bdd37ba86c8330b58bd1787fdf5e46