### PR TITLE
refactor: simplify main and update docker command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,4 @@ EXPOSE 8000
 
 USER app
 
-CMD ["python", "main.py"]
+CMD ["uvicorn", "web_app.server:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/main.py
+++ b/main.py
@@ -1,14 +1,13 @@
 """Входная точка для запуска сервиса DocRouter.
 
 Запускает сервер FastAPI, определённый в модуле ``web_app.server``.
-Команда позволяет указать адрес и порт, а также включить автоматическую
-перезагрузку кода при разработке.
+Параметры задаются через переменные окружения, что упрощает запуск.
 """
 
 from __future__ import annotations
 
-import argparse
 import logging
+import os
 import sys
 from pathlib import Path
 
@@ -23,22 +22,23 @@ logger = logging.getLogger(__name__)
 
 
 def main() -> None:
-    """Точка входа CLI.
+    """Точка входа для запуска сервера.
 
-    Запускает сервер FastAPI с указанными параметрами.
+    Значения берутся из переменных окружения:
+    ``HOST`` (по умолчанию ``0.0.0.0``),
+    ``PORT`` (по умолчанию ``8000``)
+    и ``RELOAD`` (``true``/``false``, по умолчанию ``false``).
     """
 
-    parser = argparse.ArgumentParser(description="Start DocRouter FastAPI server")
-    parser.add_argument("--host", default="0.0.0.0", help="Host address")
-    parser.add_argument("--port", type=int, default=8000, help="Port to listen on")
-    parser.add_argument("--reload", action="store_true", help="Enable autoreload")
-    args = parser.parse_args()
+    host = os.getenv("HOST", "0.0.0.0")
+    port = int(os.getenv("PORT", "8000"))
+    reload = os.getenv("RELOAD", "false").lower() in {"1", "true", "yes"}
 
     # Настраиваем логирование согласно конфигу
     setup_logging(LOG_LEVEL, None)
-    logger.info("Starting FastAPI server on %s:%s", args.host, args.port)
+    logger.info("Starting FastAPI server on %s:%s", host, port)
 
-    uvicorn.run("web_app.server:app", host=args.host, port=args.port, reload=args.reload)
+    uvicorn.run("web_app.server:app", host=host, port=port, reload=reload)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- simplify main script: use HOST/PORT/RELOAD env vars instead of argparse
- start container with uvicorn directly

## Testing
- `pytest`
- `docker-compose up` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd739e52c8330989173100da258dc