### PR TITLE
refactor: remove unused CLI dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,10 @@
-.PHONY: build-frontend
+.PHONY: build-frontend run up
+
 build-frontend:
-	npm run build
+	npx tsc
+
+run:
+	python main.py
+
+up:
+	docker compose up --build

--- a/package.json
+++ b/package.json
@@ -4,8 +4,5 @@
   "type": "module",
   "devDependencies": {
     "typescript": "^5.6.3"
-  },
-  "scripts": {
-    "build": "tsc"
   }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,7 @@
 fastapi
 uvicorn
 httpx
-requests
 pydantic
-python-dotenv
 pillow
 pytesseract
 numpy

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -5,7 +5,6 @@ import threading
 import time
 from pathlib import Path
 
-import requests
 import uvicorn
 from PIL import Image
 import pytest
@@ -41,7 +40,7 @@ class LiveClient:
         self.thread.start()
         while not getattr(self.server, "started", False):
             time.sleep(0.01)
-        self.session = requests.Session()
+        self.session = httpx.Client()
         return self
 
     def __exit__(self, exc_type, exc, tb):


### PR DESCRIPTION
## Summary
- drop unused python-dotenv and requests
- switch web app tests to httpx client
- move TypeScript build to Makefile and add run targets

## Testing
- `npx tsc`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bdd7336ccc8330973e5c54ef4faff4