### PR TITLE
refactor: move directory processing to service

### DIFF
--- a/src/services/__init__.py
+++ b/src/services/__init__.py
@@ -1,1 +1,3 @@
-"""Сервисы для интеграции с внешними API."""
+"""Сервисы для интеграции и фоновой обработки."""
+
+from .directory_processor import process_input_directory  # noqa: F401

--- a/tests/test_directory_processor_recursive.py
+++ b/tests/test_directory_processor_recursive.py
@@ -4,14 +4,14 @@ import asyncio
 
 sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
 
-from docrouter import process_directory
+from services.directory_processor import process_input_directory
 import metadata_generation
 from models import Metadata
 from config import GENERAL_FOLDER_NAME
 from web_app import db as database
 
 
-def test_process_directory_preserves_subdirs(tmp_path, monkeypatch):
+def test_process_input_directory_preserves_subdirs(tmp_path, monkeypatch):
     input_dir = tmp_path / "input" / "sub1" / "sub2"
     input_dir.mkdir(parents=True)
     file_path = input_dir / "data.txt"
@@ -24,7 +24,7 @@ def test_process_directory_preserves_subdirs(tmp_path, monkeypatch):
 
     dest_root = tmp_path / "Archive"
     database.init_db()
-    asyncio.run(process_directory(tmp_path / "input", dest_root))
+    asyncio.run(process_input_directory(tmp_path / "input", dest_root))
 
     expected = dest_root / GENERAL_FOLDER_NAME / "sub1" / "sub2" / "2024-01-01__data.txt"
     assert not expected.exists()

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -8,7 +8,7 @@ import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
 
-from docrouter import process_directory
+from services.directory_processor import process_input_directory
 
 
 def test_parse_error_moves_file_and_creates_json(tmp_path):
@@ -23,7 +23,7 @@ def test_parse_error_moves_file_and_creates_json(tmp_path):
     cwd = os.getcwd()
     os.chdir(tmp_path)
     try:
-        asyncio.run(process_directory(input_dir, dest_root, dry_run=True))
+        asyncio.run(process_input_directory(input_dir, dest_root, dry_run=True))
     finally:
         os.chdir(cwd)
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -8,7 +8,7 @@ import pytest
 sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
 
 from file_utils import extract_text, UnsupportedFileType
-from docrouter import process_directory
+from services.directory_processor import process_input_directory
 import metadata_generation
 from models import Metadata
 from web_app import db as database
@@ -23,7 +23,7 @@ def test_extract_text_logs_error_for_unknown_extension(tmp_path, caplog):
     assert "Unsupported/unknown file extension" in caplog.text
 
 
-def test_process_directory_logs(tmp_path, monkeypatch, caplog):
+def test_process_input_directory_logs(tmp_path, monkeypatch, caplog):
     input_dir = tmp_path / "input"
     input_dir.mkdir()
     file_path = input_dir / "data.txt"
@@ -38,8 +38,7 @@ def test_process_directory_logs(tmp_path, monkeypatch, caplog):
     database.init_db()
 
     with caplog.at_level(logging.INFO):
-        asyncio.run(process_directory(input_dir, dest_root))
-
+        asyncio.run(process_input_directory(input_dir, dest_root))
     assert f"Processing directory {input_dir}" in caplog.text
     assert f"Processing file {file_path}" in caplog.text
     assert f"Pending {file_path} due to missing" in caplog.text


### PR DESCRIPTION
## Summary
- remove legacy docrouter module
- add directory processor service for backend use
- update tests to call new service

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bdd71d43f48330ae5bbce8a36a8d49