### PR TITLE
Handle missing Tesseract executable gracefully

### DIFF
--- a/src/file_utils/image_ocr.py
+++ b/src/file_utils/image_ocr.py
@@ -26,6 +26,10 @@ def extract_text_image(image_path: Union[str, Path], language: str = "eng") -> s
     img = Image.open(Path(image_path))
     try:
         return pytesseract.image_to_string(img, lang=language)
+    except pytesseract.TesseractNotFoundError as exc:
+        raise RuntimeError(
+            "Tesseract OCR executable not found. Please install Tesseract and ensure it's in PATH."
+        ) from exc
     except pytesseract.TesseractError as exc:
         if language != "eng":
             logger.warning(

--- a/tests/test_image_ocr.py
+++ b/tests/test_image_ocr.py
@@ -3,6 +3,7 @@ import shutil
 import pytest
 
 from file_utils import extract_text
+from file_utils.image_ocr import extract_text_image
 
 
 @pytest.mark.skipif(shutil.which("tesseract") is None, reason="tesseract not installed")
@@ -27,3 +28,20 @@ def test_extract_text_from_image_fallback_language(tmp_path):
 
     text = extract_text(image_path, language='xyz')
     assert 'OCR' in text
+
+
+def test_extract_text_image_tesseract_not_found(monkeypatch, tmp_path):
+    image = Image.new('RGB', (10, 10), color='white')
+    image_path = tmp_path / 'sample.png'
+    image.save(image_path)
+
+    import pytesseract
+
+    def fake_image_to_string(*_args, **_kwargs):
+        raise pytesseract.TesseractNotFoundError()
+
+    monkeypatch.setattr(pytesseract, 'image_to_string', fake_image_to_string)
+
+    with pytest.raises(RuntimeError) as exc:
+        extract_text_image(image_path)
+    assert 'Tesseract OCR executable not found' in str(exc.value)


### PR DESCRIPTION
## Summary
- raise a clear runtime error when Tesseract OCR binary is absent
- cover missing Tesseract scenario with unit test

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bdd8cdcebc83309327314027ab1b4e