### PR TITLE
Добавить поле описания для файлов

### DIFF
--- a/src/web_app/routes/files.py
+++ b/src/web_app/routes/files.py
@@ -223,6 +223,8 @@ async def update_file(file_id: str, data: dict = Body(...)):
     if not record:
         raise HTTPException(status_code=404, detail="File not found")
     metadata_updates = data.get("metadata") or {}
+    allowed_fields = set(Metadata.model_fields.keys())
+    metadata_updates = {k: v for k, v in metadata_updates.items() if k in allowed_fields}
     new_metadata_dict = record.metadata.model_dump()
     if metadata_updates:
         new_metadata_dict.update(metadata_updates)

--- a/src/web_app/static/files.ts
+++ b/src/web_app/static/files.ts
@@ -17,6 +17,7 @@ let editSubcategory: HTMLInputElement;
 let editIssuer: HTMLInputElement;
 let editDate: HTMLInputElement;
 let editName: HTMLInputElement;
+let editDescription: HTMLTextAreaElement;
 let nameOriginalRadio: HTMLInputElement | null;
 let nameLatinRadio: HTMLInputElement | null;
 let nameOriginalLabel: HTMLElement | null;
@@ -39,6 +40,7 @@ export function setupFiles() {
   editIssuer = document.getElementById('edit-issuer') as HTMLInputElement;
   editDate = document.getElementById('edit-date') as HTMLInputElement;
   editName = document.getElementById('edit-name') as HTMLInputElement;
+  editDescription = document.getElementById('edit-description') as HTMLTextAreaElement;
   nameOriginalRadio = document.getElementById('name-original') as HTMLInputElement;
   nameLatinRadio = document.getElementById('name-latin') as HTMLInputElement;
   nameOriginalLabel = document.getElementById('name-original-label');
@@ -61,6 +63,7 @@ export function setupFiles() {
         issuer: editIssuer.value.trim(),
         date: editDate.value,
         suggested_name: editName.value.trim(),
+        description: editDescription.value.trim(),
       },
     };
     (Object.keys(payload.metadata) as (keyof FileMetadata)[]).forEach((k) => {
@@ -171,6 +174,12 @@ export async function refreshFiles(force = false) {
       tagsTd.textContent = tagsText;
       tr.appendChild(tagsTd);
 
+      const descTd = document.createElement('td');
+      const desc = f.metadata?.description ? f.metadata.description.substring(0, 100) : '';
+      descTd.textContent = desc;
+      descTd.classList.add('description');
+      tr.appendChild(descTd);
+
       const statusTd = document.createElement('td');
       statusTd.textContent = f.status;
       tr.appendChild(statusTd);
@@ -229,6 +238,7 @@ function openMetadataModal(file: FileInfo) {
   const orig = m.suggested_name || '';
   const latin = m.suggested_name_translit || orig;
   editName.value = orig;
+  editDescription.value = m.description || '';
 
   if (nameOriginalRadio) {
     nameOriginalRadio.value = orig;

--- a/src/web_app/static/style.css
+++ b/src/web_app/static/style.css
@@ -33,6 +33,21 @@ form { display: flex; flex-direction: column; gap: var(--spacing-md); }
 #files-table th {
   background: var(--color-surface-alt);
 }
+
+#edit-description {
+  min-height: 5em;
+  resize: vertical;
+}
+
+#files-table td.description {
+  max-width: 20em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+#files-table th.description {
+  max-width: 20em;
+}
 button, input[type="submit"] { padding: var(--spacing-sm) var(--spacing-md); border: none; background-color: var(--color-primary); color: var(--color-surface); border-radius: 4px; cursor: pointer; }
 button:hover, input[type="submit"]:hover { background-color: var(--color-primary-hover); }
 #upload-progress { width: 100%; margin-top: var(--spacing-md); }
@@ -124,7 +139,9 @@ button:hover, input[type="submit"]:hover { background-color: var(--color-primary
   #files-table th:nth-child(2),
   #files-table td:nth-child(2),
   #files-table th:nth-child(3),
-  #files-table td:nth-child(3) { display: none; }
+  #files-table td:nth-child(3),
+  #files-table th:nth-child(4),
+  #files-table td:nth-child(4) { display: none; }
   #folder-tree { display: none; }
 }
 

--- a/src/web_app/static/types.ts
+++ b/src/web_app/static/types.ts
@@ -12,6 +12,7 @@ export interface FileMetadata {
   tags_en?: string[];
   suggested_name?: string;
   suggested_name_translit?: string;
+  description?: string;
 }
 
 export interface FileInfo {

--- a/src/web_app/templates/index.html
+++ b/src/web_app/templates/index.html
@@ -62,6 +62,7 @@
                     <th>Путь</th>
                     <th>Категория</th>
                     <th>Теги</th>
+                    <th class="description">Описание</th>
                     <th>Статус</th>
                     <th>Действия</th>
                 </tr>
@@ -95,6 +96,7 @@
                 <label>Организация: <input type="text" id="edit-issuer" /></label>
                 <label>Дата: <input type="date" id="edit-date" /></label>
                 <label>Имя: <input type="text" id="edit-name" /></label>
+                <label>Описание: <textarea id="edit-description"></textarea></label>
                 <div id="name-options">
                     <label><input type="radio" name="name-choice" id="name-original" /> <span id="name-original-label"></span></label>
                     <label><input type="radio" name="name-choice" id="name-latin" /> <span id="name-latin-label"></span></label>


### PR DESCRIPTION
## Summary
- Добавлено поле описания в форму редактирования метаданных и колонку в таблицу файлов
- Клиент заполняет и отправляет описание, сервер принимает обновление поля `description`
- Стили обновлены для нового текстового поля и столбца, адаптация под мобильные устройства

## Testing
- `npx tsc --noEmit`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bdd9a4ded4833084bf272de22f2443