### PR TITLE
feat: add metadata summary

### DIFF
--- a/src/metadata_generation.py
+++ b/src/metadata_generation.py
@@ -248,7 +248,7 @@ async def generate_metadata(
     The returned dictionary always contains the following fields:
     ``category``, ``subcategory``, ``issuer``, ``person``, ``doc_type``,
     ``date``, ``amount``, ``counterparty``, ``document_number``, ``due_date``, ``currency``, ``tags``, ``tags_ru``,
-    ``tags_en``, ``suggested_filename``, ``description``, ``needs_new_folder``.
+    ``tags_en``, ``suggested_filename``, ``description``, ``summary``, ``needs_new_folder``.
     """
     if analyzer is None:
         analyzer = OpenRouterAnalyzer()
@@ -290,6 +290,7 @@ async def generate_metadata(
         "tags_ru": [],
         "tags_en": [],
         "suggested_filename": None,
+        "summary": None,
         "description": None,
         "needs_new_folder": False,
     }

--- a/src/models.py
+++ b/src/models.py
@@ -25,6 +25,7 @@ class Metadata(BaseModel):
     tags_en: List[str] = Field(default_factory=list)
     suggested_filename: Optional[str] = None
     suggested_name: Optional[str] = None
+    summary: Optional[str] = None
     description: Optional[str] = None
     needs_new_folder: bool = False
     extracted_text: Optional[str] = None

--- a/src/prompt_templates.py
+++ b/src/prompt_templates.py
@@ -35,7 +35,8 @@ def build_metadata_prompt(
         "Выбирай person/category строго из Existing folders index, если совпадение найдено; needs_new_folder=true только при полном отсутствии.\n"
         "Return a JSON object with the fields: category, subcategory, needs_new_folder (boolean), issuer, person, doc_type, "
         "date, amount, counterparty, document_number, due_date, currency, tags_ru (list of strings), tags_en (list of strings),"
-        "suggested_filename, description.\n"
+        "suggested_filename, description, summary.\n"
+        "Field 'summary' must briefly summarize the document in 1-2 sentences.\n"
         "Field 'person' must be in the format 'Фамилия Имя Отчество'; do not use the person's name in category or subcategory.\n"
         f"Document text:\n{text}"
     )

--- a/src/web_app/routes/upload.py
+++ b/src/web_app/routes/upload.py
@@ -75,6 +75,7 @@ async def upload_file(
         metadata.language = lang_display
 
         meta_dict = metadata.model_dump()
+        meta_dict["summary"] = metadata.summary
         # Раскладываем файл по директориям без создания недостающих
         dest_path, missing, _ = place_file(
             str(temp_path),
@@ -179,6 +180,7 @@ async def upload_images(
         metadata.language = lang_display
 
         meta_dict = metadata.model_dump()
+        meta_dict["summary"] = metadata.summary
         dest_path, missing, _ = place_file(
             str(pdf_path),
             meta_dict,

--- a/src/web_app/static/dist/files.js
+++ b/src/web_app/static/dist/files.js
@@ -24,6 +24,8 @@ let editSubcategory;
 let editIssuer;
 let editDate;
 let editName;
+let editDescription;
+let editSummary;
 let nameOriginalRadio;
 let nameLatinRadio;
 let nameOriginalLabel;
@@ -45,6 +47,8 @@ export function setupFiles() {
     editIssuer = document.getElementById('edit-issuer');
     editDate = document.getElementById('edit-date');
     editName = document.getElementById('edit-name');
+    editDescription = document.getElementById('edit-description');
+    editSummary = document.getElementById('edit-summary');
     nameOriginalRadio = document.getElementById('name-original');
     nameLatinRadio = document.getElementById('name-latin');
     nameOriginalLabel = document.getElementById('name-original-label');
@@ -65,6 +69,7 @@ export function setupFiles() {
                 issuer: editIssuer.value.trim(),
                 date: editDate.value,
                 suggested_name: editName.value.trim(),
+                description: editDescription.value.trim(),
             },
         };
         Object.keys(payload.metadata).forEach((k) => {
@@ -153,7 +158,7 @@ export function refreshFiles() {
             const files = yield resp.json();
             list.innerHTML = '';
             files.forEach((f) => {
-                var _a, _b;
+                var _a, _b, _c, _d;
                 const tr = document.createElement('tr');
                 tr.dataset.id = f.id;
                 const pathTd = document.createElement('td');
@@ -169,6 +174,16 @@ export function refreshFiles() {
                 const tagsText = Array.isArray(tags) ? tags.join(', ') : '';
                 tagsTd.textContent = tagsText;
                 tr.appendChild(tagsTd);
+                const summaryTd = document.createElement('td');
+                const summary = ((_c = f.metadata) === null || _c === void 0 ? void 0 : _c.summary) ? f.metadata.summary.substring(0, 100) : '';
+                summaryTd.textContent = summary;
+                summaryTd.classList.add('summary');
+                tr.appendChild(summaryTd);
+                const descTd = document.createElement('td');
+                const desc = ((_d = f.metadata) === null || _d === void 0 ? void 0 : _d.description) ? f.metadata.description.substring(0, 100) : '';
+                descTd.textContent = desc;
+                descTd.classList.add('description');
+                tr.appendChild(descTd);
                 const statusTd = document.createElement('td');
                 statusTd.textContent = f.status;
                 tr.appendChild(statusTd);
@@ -222,6 +237,8 @@ function openMetadataModal(file) {
     const orig = m.suggested_name || '';
     const latin = m.suggested_name_translit || orig;
     editName.value = orig;
+    editDescription.value = m.description || '';
+    editSummary.value = m.summary || '';
     if (nameOriginalRadio) {
         nameOriginalRadio.value = orig;
         nameOriginalRadio.checked = true;

--- a/src/web_app/static/files.ts
+++ b/src/web_app/static/files.ts
@@ -18,6 +18,7 @@ let editIssuer: HTMLInputElement;
 let editDate: HTMLInputElement;
 let editName: HTMLInputElement;
 let editDescription: HTMLTextAreaElement;
+let editSummary: HTMLTextAreaElement;
 let nameOriginalRadio: HTMLInputElement | null;
 let nameLatinRadio: HTMLInputElement | null;
 let nameOriginalLabel: HTMLElement | null;
@@ -41,6 +42,7 @@ export function setupFiles() {
   editDate = document.getElementById('edit-date') as HTMLInputElement;
   editName = document.getElementById('edit-name') as HTMLInputElement;
   editDescription = document.getElementById('edit-description') as HTMLTextAreaElement;
+  editSummary = document.getElementById('edit-summary') as HTMLTextAreaElement;
   nameOriginalRadio = document.getElementById('name-original') as HTMLInputElement;
   nameLatinRadio = document.getElementById('name-latin') as HTMLInputElement;
   nameOriginalLabel = document.getElementById('name-original-label');
@@ -174,6 +176,12 @@ export async function refreshFiles(force = false) {
       tagsTd.textContent = tagsText;
       tr.appendChild(tagsTd);
 
+      const summaryTd = document.createElement('td');
+      const summary = f.metadata?.summary ? f.metadata.summary.substring(0, 100) : '';
+      summaryTd.textContent = summary;
+      summaryTd.classList.add('summary');
+      tr.appendChild(summaryTd);
+
       const descTd = document.createElement('td');
       const desc = f.metadata?.description ? f.metadata.description.substring(0, 100) : '';
       descTd.textContent = desc;
@@ -239,6 +247,7 @@ function openMetadataModal(file: FileInfo) {
   const latin = m.suggested_name_translit || orig;
   editName.value = orig;
   editDescription.value = m.description || '';
+  editSummary.value = m.summary || '';
 
   if (nameOriginalRadio) {
     nameOriginalRadio.value = orig;

--- a/src/web_app/static/style.css
+++ b/src/web_app/static/style.css
@@ -39,6 +39,11 @@ form { display: flex; flex-direction: column; gap: var(--spacing-md); }
   resize: vertical;
 }
 
+#edit-summary {
+  min-height: 3em;
+  resize: vertical;
+}
+
 #files-table td.description {
   max-width: 20em;
   white-space: nowrap;
@@ -46,6 +51,16 @@ form { display: flex; flex-direction: column; gap: var(--spacing-md); }
   text-overflow: ellipsis;
 }
 #files-table th.description {
+  max-width: 20em;
+}
+
+#files-table td.summary {
+  max-width: 20em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+#files-table th.summary {
   max-width: 20em;
 }
 button, input[type="submit"] { padding: var(--spacing-sm) var(--spacing-md); border: none; background-color: var(--color-primary); color: var(--color-surface); border-radius: 4px; cursor: pointer; }
@@ -141,7 +156,9 @@ button:hover, input[type="submit"]:hover { background-color: var(--color-primary
   #files-table th:nth-child(3),
   #files-table td:nth-child(3),
   #files-table th:nth-child(4),
-  #files-table td:nth-child(4) { display: none; }
+  #files-table td:nth-child(4),
+  #files-table th:nth-child(5),
+  #files-table td:nth-child(5) { display: none; }
   #folder-tree { display: none; }
 }
 

--- a/src/web_app/static/types.ts
+++ b/src/web_app/static/types.ts
@@ -13,6 +13,7 @@ export interface FileMetadata {
   suggested_name?: string;
   suggested_name_translit?: string;
   description?: string;
+  summary?: string;
 }
 
 export interface FileInfo {

--- a/src/web_app/templates/index.html
+++ b/src/web_app/templates/index.html
@@ -62,6 +62,7 @@
                     <th>Путь</th>
                     <th>Категория</th>
                     <th>Теги</th>
+                    <th class="summary">Сводка</th>
                     <th class="description">Описание</th>
                     <th>Статус</th>
                     <th>Действия</th>
@@ -96,6 +97,7 @@
                 <label>Организация: <input type="text" id="edit-issuer" /></label>
                 <label>Дата: <input type="date" id="edit-date" /></label>
                 <label>Имя: <input type="text" id="edit-name" /></label>
+                <label>Сводка: <textarea id="edit-summary" readonly></textarea></label>
                 <label>Описание: <textarea id="edit-description"></textarea></label>
                 <div id="name-options">
                     <label><input type="radio" name="name-choice" id="name-original" /> <span id="name-original-label"></span></label>


### PR DESCRIPTION
## Summary
- add optional summary field to metadata and persist it
- request summary from LLM and include in defaults
- show summary in file table and metadata modal

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdda89dff4833093dad9ba5e344edd