### PR TITLE
Добавлен поиск файлов по тексту

### DIFF
--- a/src/web_app/db.py
+++ b/src/web_app/db.py
@@ -257,6 +257,21 @@ def list_files() -> List[FileRecord]:
     return [_row_to_record(r) for r in rows]
 
 
+def search_files(query: str) -> List[FileRecord]:
+    conn = _get_conn()
+    pattern = f"%{query}%"
+    rows = conn.execute(
+        """
+        SELECT * FROM files
+        WHERE metadata LIKE ?
+           OR person LIKE ?
+           OR passport_number LIKE ?
+        """,
+        (pattern, pattern, pattern),
+    ).fetchall()
+    return [_row_to_record(r) for r in rows]
+
+
 def add_chat_message(
     file_id: str,
     role: str,

--- a/src/web_app/routes/files.py
+++ b/src/web_app/routes/files.py
@@ -225,6 +225,11 @@ async def list_files(force: bool = False):
     return database.list_files()
 
 
+@router.get("/files/search", response_model=list[FileRecord])
+async def search_files_route(q: str):
+    return database.search_files(q)
+
+
 
 @router.patch("/files/{file_id}", response_model=FileRecord)
 async def update_file(file_id: str, data: dict = Body(...)):

--- a/src/web_app/static/dist/files.js
+++ b/src/web_app/static/dist/files.js
@@ -15,6 +15,7 @@ let list;
 let textPreview;
 let tagLanguage;
 let displayLangSelect;
+let searchInput;
 let previewModal;
 let previewFrame;
 let metadataModal;
@@ -38,6 +39,7 @@ export function setupFiles() {
     textPreview = document.getElementById('text-preview');
     tagLanguage = document.getElementById('tag-language');
     displayLangSelect = document.getElementById('display-lang');
+    searchInput = document.getElementById('search-input');
     previewModal = document.getElementById('preview-modal');
     previewFrame = document.getElementById('preview-frame');
     metadataModal = document.getElementById('metadata-modal');
@@ -56,7 +58,7 @@ export function setupFiles() {
     const refreshBtn = document.getElementById('refresh-btn');
     displayLangSelect === null || displayLangSelect === void 0 ? void 0 : displayLangSelect.addEventListener('change', () => {
         displayLang = displayLangSelect.value;
-        refreshFiles();
+        refreshFiles(false, (searchInput === null || searchInput === void 0 ? void 0 : searchInput.value.trim()) || '');
     });
     editForm.addEventListener('submit', (e) => __awaiter(this, void 0, void 0, function* () {
         e.preventDefault();
@@ -135,7 +137,7 @@ export function setupFiles() {
         closeModal(metadataModal);
         currentEditId = null;
     });
-    tagLanguage.addEventListener('change', () => refreshFiles());
+    tagLanguage.addEventListener('change', () => refreshFiles(false, (searchInput === null || searchInput === void 0 ? void 0 : searchInput.value.trim()) || ''));
     nameOriginalRadio === null || nameOriginalRadio === void 0 ? void 0 : nameOriginalRadio.addEventListener('change', () => {
         if (nameOriginalRadio.checked)
             editName.value = nameOriginalRadio.value;
@@ -145,15 +147,25 @@ export function setupFiles() {
             editName.value = nameLatinRadio.value;
     });
     refreshBtn === null || refreshBtn === void 0 ? void 0 : refreshBtn.addEventListener('click', () => {
-        refreshFiles(true);
+        refreshFiles(true, (searchInput === null || searchInput === void 0 ? void 0 : searchInput.value.trim()) || '');
         refreshFolderTree();
+    });
+    searchInput === null || searchInput === void 0 ? void 0 : searchInput.addEventListener('input', () => {
+        const term = searchInput.value.trim();
+        if (term)
+            refreshFiles(false, term);
+        else
+            refreshFiles();
     });
     refreshFiles();
 }
 export function refreshFiles() {
-    return __awaiter(this, arguments, void 0, function* (force = false) {
+    return __awaiter(this, arguments, void 0, function* (force = false, q = '') {
         try {
-            const resp = yield apiRequest(`/files${force ? '?force=1' : ''}`);
+            const url = q
+                ? `/files/search?q=${encodeURIComponent(q)}`
+                : `/files${force ? '?force=1' : ''}`;
+            const resp = yield apiRequest(url);
             if (!resp.ok)
                 throw new Error();
             const files = yield resp.json();

--- a/src/web_app/static/files.ts
+++ b/src/web_app/static/files.ts
@@ -8,6 +8,7 @@ let list: HTMLElement;
 let textPreview: HTMLElement;
 let tagLanguage: HTMLSelectElement;
 let displayLangSelect: HTMLSelectElement;
+let searchInput: HTMLInputElement;
 let previewModal: HTMLElement;
 let previewFrame: HTMLIFrameElement;
 let metadataModal: HTMLElement;
@@ -32,6 +33,7 @@ export function setupFiles() {
   textPreview = document.getElementById('text-preview')!;
   tagLanguage = document.getElementById('tag-language') as HTMLSelectElement;
   displayLangSelect = document.getElementById('display-lang') as HTMLSelectElement;
+  searchInput = document.getElementById('search-input') as HTMLInputElement;
   previewModal = document.getElementById('preview-modal')!;
   previewFrame = document.getElementById('preview-frame') as HTMLIFrameElement;
   metadataModal = document.getElementById('metadata-modal')!;
@@ -51,7 +53,7 @@ export function setupFiles() {
 
   displayLangSelect?.addEventListener('change', () => {
     displayLang = displayLangSelect.value;
-    refreshFiles();
+    refreshFiles(false, searchInput?.value.trim() || '');
   });
 
   editForm.addEventListener('submit', async (e) => {
@@ -134,7 +136,7 @@ export function setupFiles() {
     currentEditId = null;
   });
 
-  tagLanguage.addEventListener('change', () => refreshFiles());
+  tagLanguage.addEventListener('change', () => refreshFiles(false, searchInput?.value.trim() || ''));
   nameOriginalRadio?.addEventListener('change', () => {
     if (nameOriginalRadio.checked) editName.value = nameOriginalRadio.value;
   });
@@ -143,16 +145,25 @@ export function setupFiles() {
   });
 
   refreshBtn?.addEventListener('click', () => {
-    refreshFiles(true);
+    refreshFiles(true, searchInput?.value.trim() || '');
     refreshFolderTree();
+  });
+
+  searchInput?.addEventListener('input', () => {
+    const term = searchInput.value.trim();
+    if (term) refreshFiles(false, term);
+    else refreshFiles();
   });
 
   refreshFiles();
 }
 
-export async function refreshFiles(force = false) {
+export async function refreshFiles(force = false, q = '') {
   try {
-    const resp = await apiRequest(`/files${force ? '?force=1' : ''}`);
+    const url = q
+      ? `/files/search?q=${encodeURIComponent(q)}`
+      : `/files${force ? '?force=1' : ''}`;
+    const resp = await apiRequest(url);
     if (!resp.ok) throw new Error();
     const files: FileInfo[] = await resp.json();
 

--- a/src/web_app/templates/index.html
+++ b/src/web_app/templates/index.html
@@ -40,6 +40,7 @@
 
         <h2>Загруженные файлы</h2>
         <button id="refresh-btn" type="button">Обновить</button>
+        <input id="search-input" type="text" placeholder="Поиск" />
 
         <!-- Оба селектора сохранены -->
         <label for="display-lang">Язык отображения:</label>

--- a/tests/test_full_text_search.py
+++ b/tests/test_full_text_search.py
@@ -1,0 +1,33 @@
+import importlib
+import sys
+import types
+
+dummy_server = types.ModuleType("server")
+dummy_server.app = None
+sys.modules.setdefault("web_app.server", dummy_server)
+db = importlib.import_module("web_app.db")
+from models import Metadata
+
+
+def test_full_text_search(tmp_path):
+    original_path = db._DB_PATH
+    original_conn = db._conn
+    try:
+        db._DB_PATH = tmp_path / "test.sqlite"
+        db._conn = None
+        db.init_db()
+
+        db.add_file("1", "a.pdf", Metadata(extracted_text="Иван Петров паспорт 1234"), "a.pdf")
+        db.add_file("2", "b.pdf", Metadata(extracted_text="Анна Сидорова паспорт 5678"), "b.pdf")
+
+        res1 = db.search_files("Иван")
+        assert [r.id for r in res1] == ["1"]
+
+        res2 = db.search_files("5678")
+        assert [r.id for r in res2] == ["2"]
+    finally:
+        if db._conn is not None:
+            db._conn.close()
+        db._conn = original_conn
+        db._DB_PATH = original_path
+


### PR DESCRIPTION
## Summary
- add SQL LIKE based search in database and route
- implement frontend search field and logic
- cover search functionality with tests

## Testing
- `npx tsc`
- `pytest` *(fails: libGL.so.1 missing)*
- `apt-get update` *(fails: repository 403)*
- `pytest tests/test_full_text_search.py`


------
https://chatgpt.com/codex/tasks/task_e_68bde178ba888330acbedb22497aad97