### PR TITLE
Обработка ошибок запуска uvicorn

### DIFF
--- a/main.py
+++ b/main.py
@@ -38,7 +38,11 @@ def main() -> None:
     setup_logging(LOG_LEVEL, None)
     logger.info("Starting FastAPI server on %s:%s", host, port)
 
-    uvicorn.run("web_app.server:app", host=host, port=port, reload=reload)
+    try:
+        uvicorn.run("web_app.server:app", host=host, port=port, reload=reload)
+    except Exception:
+        logger.exception("Не удалось запустить сервер")
+        sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- обернул запуск Uvicorn в `try/except`
- добавил логирование стектрейса и выход с ненулевым кодом при ошибке

## Testing
- `pytest` *(ошибка: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68bde90c4ec08330b8fa1e561a9a3320