### PR TITLE
feat: optional db reset

### DIFF
--- a/env.example
+++ b/env.example
@@ -26,3 +26,6 @@ TESSERACT_LANG=eng
 OUTPUT_DIR=Archive
 # Имя папки для общих документов, если не указан владелец
 GENERAL_FOLDER_NAME=Shared
+
+# Принудительный сброс схемы БД при запуске (1 — сбросить)
+DOCROUTER_RESET_DB=0

--- a/src/web_app/server.py
+++ b/src/web_app/server.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
+import os
 
 from fastapi import FastAPI, Request
 from fastapi.responses import HTMLResponse
@@ -60,7 +61,7 @@ except Exception:
 logger = logging.getLogger(__name__)
 
 # --------- Инициализация БД ----------
-database.init_db()
+database.init_db(force_reset=os.getenv("DOCROUTER_RESET_DB") == "1")
 
 # --------- Подключение маршрутов ----------
 app.include_router(upload.router)


### PR DESCRIPTION
## Summary
- allow disabling implicit DROP TABLE and add optional reset flag via DOCROUTER_RESET_DB
- wire server to pass reset flag based on env var
- document DOCROUTER_RESET_DB in env.example

## Testing
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68bde90e051c8330bef8e80cd50b7521