### PR TITLE
feat: add collapsible folder tree

### DIFF
--- a/src/web_app/static/folders.ts
+++ b/src/web_app/static/folders.ts
@@ -7,11 +7,12 @@ let folderTree: HTMLElement;
 function renderNodes(container: HTMLElement, nodes: FolderNode[]): void {
   nodes.forEach((node) => {
     const li = document.createElement('li');
-    const nameSpan = document.createElement('span');
-    nameSpan.textContent = node.name;
-    li.appendChild(nameSpan);
 
-    // Если есть вложенные файлы или директории — строим дерево
+    const details = document.createElement('details');
+    const summary = document.createElement('summary');
+    summary.textContent = node.name;
+    details.appendChild(summary);
+
     if ((node.files && node.files.length) || (node.children && node.children.length)) {
       const ul = document.createElement('ul');
 
@@ -46,9 +47,10 @@ function renderNodes(container: HTMLElement, nodes: FolderNode[]): void {
 
       // Рекурсивно отрисовываем вложенные папки
       renderNodes(ul, node.children || []);
-      li.appendChild(ul);
+      details.appendChild(ul);
     }
 
+    li.appendChild(details);
     container.appendChild(li);
   });
 }

--- a/src/web_app/static/style.css
+++ b/src/web_app/static/style.css
@@ -104,8 +104,11 @@ button:hover, input[type="submit"]:hover { background-color: var(--color-primary
   border: 1px solid var(--color-border);
   margin-top: var(--spacing-md);
 }
-#folder-tree { list-style: none; padding-left: var(--spacing-md); }
+#folder-tree,
+#folder-tree ul { list-style: none; padding-left: var(--spacing-md); }
 #folder-tree li { margin: var(--spacing-xs) 0; }
+#folder-tree details { padding-left: var(--spacing-xs); }
+#folder-tree summary { cursor: pointer; }
 .modal { display: none; position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.4); justify-content: center; align-items: center; }
 .modal__content { background: var(--color-surface); padding: var(--spacing-md); border-radius: 4px; width: 90%; max-width: 400px; }
 .modal__close { float: right; cursor: pointer; }


### PR DESCRIPTION
## Summary
- wrap folder entries in <details>/<summary> so nested lists show only when expanded
- style folder tree details/summary for cleaner UI

## Testing
- `npx tsc`
- `pytest` *(fails: ImportError: libGL.so.1; attempted `apt-get update` but repositories are inaccessible)*

------
https://chatgpt.com/codex/tasks/task_e_68bded089f108330887c831c83aff510