### PR TITLE
fix: auto crop after cropper ready

### DIFF
--- a/src/web_app/static/imageEditor.ts
+++ b/src/web_app/static/imageEditor.ts
@@ -87,8 +87,10 @@ export function openImageEditModal(fileObj: { blob: Blob; name: string }) {
     ctx.drawImage(img, 0, 0);
     cropper?.destroy();
     const CropperCtor = (window as any).Cropper || (globalThis as any).Cropper;
-    cropper = new CropperCtor(editCanvas, { viewMode: 1 });
-    autoCropImage();
+    cropper = new CropperCtor(editCanvas, {
+      viewMode: 1,
+      ready: autoCropImage,
+    });
     URL.revokeObjectURL(url);
   };
   img.src = url;


### PR DESCRIPTION
## Summary
- delay auto-crop until Cropper is initialized by using `ready` handler

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf1a1ab188330b783cca105de7f2f