### PR TITLE
Raise clear error for unknown metadata analyzers

### DIFF
--- a/src/metadata_generation.py
+++ b/src/metadata_generation.py
@@ -72,7 +72,10 @@ def register_analyzer(name: str) -> Callable[[type["MetadataAnalyzer"]], type["M
 
 def get_analyzer(name: str) -> type["MetadataAnalyzer"]:
     """Получить класс анализатора по имени."""
-    return _ANALYZER_REGISTRY[name]
+    try:
+        return _ANALYZER_REGISTRY[name]
+    except KeyError as exc:
+        raise ValueError(f"Analyzer '{name}' not registered") from exc
 
 
 def _parse_person_from_text(text: str) -> Optional[str]:

--- a/tests/test_metadata_generation.py
+++ b/tests/test_metadata_generation.py
@@ -283,3 +283,12 @@ def test_generate_metadata_accepts_list_of_dicts():
     meta: Metadata = result["metadata"]
     assert meta.category == "Health"
     assert set(meta.tags) == {"a", "Health"}
+
+
+def test_get_analyzer_unregistered():
+    from metadata_generation import get_analyzer
+
+    with pytest.raises(ValueError) as exc:
+        get_analyzer("unknown")
+
+    assert "unknown" in str(exc.value)


### PR DESCRIPTION
## Summary
- Validate analyzer names and raise ValueError when an analyzer isn't registered
- Test unregistered analyzer handling

## Testing
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf374d6508330ae3953ae55b604bb