### PR TITLE
Use context manager for image OCR

### DIFF
--- a/src/file_utils/image_ocr.py
+++ b/src/file_utils/image_ocr.py
@@ -23,9 +23,9 @@ def extract_text_image(image_path: Union[str, Path], language: str = "eng") -> s
     :param language: Language for OCR (default 'eng').
     :return: Extracted text as a string.
     """
-    img = Image.open(Path(image_path))
     try:
-        return pytesseract.image_to_string(img, lang=language)
+        with Image.open(Path(image_path)) as img:
+            return pytesseract.image_to_string(img, lang=language)
     except pytesseract.TesseractNotFoundError as exc:
         raise RuntimeError(
             "Tesseract OCR executable not found. Please install Tesseract and ensure it's in PATH."
@@ -36,7 +36,8 @@ def extract_text_image(image_path: Union[str, Path], language: str = "eng") -> s
                 "Tesseract language '%s' unavailable, falling back to 'eng'", language
             )
             try:
-                return pytesseract.image_to_string(img, lang="eng")
+                with Image.open(Path(image_path)) as img:
+                    return pytesseract.image_to_string(img, lang="eng")
             except pytesseract.TesseractError:
                 pass
         raise exc


### PR DESCRIPTION
## Summary
- ensure images are opened via context manager in OCR utility
- invoke Tesseract within the managed context

## Testing
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf369fbe883309af7865be5480b48