### PR TITLE
Package project and update run instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ build-frontend:
 	npx tsc
 
 run:
-	python main.py
+	python -m web_app.server
 
 up:
 	docker compose up --build

--- a/README.md
+++ b/README.md
@@ -14,8 +14,11 @@ docker compose up --build
 
 ### Python
 
+Установите проект в режиме разработки и запустите сервер:
+
 ```bash
-python main.py
+pip install -e .
+python -m web_app.server
 ```
 
 После старта интерфейс будет доступен по адресу [http://localhost:8000](http://localhost:8000), где можно загружать, просматривать и скачивать документы.

--- a/main.py
+++ b/main.py
@@ -9,10 +9,6 @@ from __future__ import annotations
 import logging
 import os
 import sys
-from pathlib import Path
-
-# Делаем пакет ``src`` доступным для импортов при запуске из корня репозитория
-sys.path.append(str(Path(__file__).resolve().parent / "src"))
 
 import uvicorn
 from config import LOG_LEVEL  # type: ignore

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,44 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "docrouter"
+version = "0.1.0"
+description = "DocRouter — локальный веб‑сервис для сортировки документов"
+readme = "README.md"
+requires-python = ">=3.8"
+dependencies = [
+    "fastapi",
+    "uvicorn",
+    "httpx",
+    "pydantic",
+    "pillow",
+    "pytesseract",
+    "numpy",
+    "opencv-python",
+    "python-docx",
+    "pymupdf",
+    "openpyxl",
+    "xlrd",
+    "python-multipart",
+    "unidecode",
+    "python-magic",
+]
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+py-modules = [
+    "logging_config",
+    "config",
+    "error_handling",
+    "file_sorter",
+    "metadata_generation",
+    "models",
+    "ocr_pipeline",
+    "prompt_templates",
+]
+include-package-data = true
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/src/web_app/server.py
+++ b/src/web_app/server.py
@@ -7,6 +7,7 @@ import os
 from fastapi import FastAPI, Request
 from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
+import uvicorn
 try:
     from fastapi.templating import Jinja2Templates
 except Exception:  # pragma: no cover
@@ -68,3 +69,16 @@ app.include_router(upload.router)
 app.include_router(files.router)
 app.include_router(folders.router)
 app.include_router(chat.router)
+
+
+def main() -> None:
+    """Запустить сервер с параметрами из переменных окружения."""
+    host = os.getenv("HOST", "0.0.0.0")
+    port = int(os.getenv("PORT", "8000"))
+    reload = os.getenv("RELOAD", "false").lower() in {"1", "true", "yes"}
+    logger.info("Starting FastAPI server on %s:%s", host, port)
+    uvicorn.run(app, host=host, port=port, reload=reload)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add pyproject for editable installation
- remove sys.path hack from main entrypoint
- allow launching server via `python -m web_app.server`
- document editable install and new run command

## Testing
- `pip install -e .` *(fails: Could not find a version that satisfies the requirement setuptools>=61)*
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf377a624833099d495d4d23b9d61