### PR TITLE
Defer autocrop until after rotation

### DIFF
--- a/src/web_app/static/dist/imageEditor.js
+++ b/src/web_app/static/dist/imageEditor.js
@@ -14,6 +14,7 @@ let rotateLeftBtn;
 let rotateRightBtn;
 let saveBtn;
 let cropper = null;
+let rotateHandler = null;
 function autoCropImage() {
     if (!cropper)
         return;
@@ -53,14 +54,30 @@ export function setupImageEditor() {
     rotateLeftBtn === null || rotateLeftBtn === void 0 ? void 0 : rotateLeftBtn.addEventListener('click', () => {
         if (!cropper)
             return;
+        if (rotateHandler) {
+            editCanvas.removeEventListener('cropend', rotateHandler);
+        }
+        rotateHandler = () => {
+            autoCropImage();
+            editCanvas.removeEventListener('cropend', rotateHandler);
+            rotateHandler = null;
+        };
+        editCanvas.addEventListener('cropend', rotateHandler);
         cropper.rotate(-90);
-        autoCropImage();
     });
     rotateRightBtn === null || rotateRightBtn === void 0 ? void 0 : rotateRightBtn.addEventListener('click', () => {
         if (!cropper)
             return;
+        if (rotateHandler) {
+            editCanvas.removeEventListener('cropend', rotateHandler);
+        }
+        rotateHandler = () => {
+            autoCropImage();
+            editCanvas.removeEventListener('cropend', rotateHandler);
+            rotateHandler = null;
+        };
+        editCanvas.addEventListener('cropend', rotateHandler);
         cropper.rotate(90);
-        autoCropImage();
     });
     saveBtn === null || saveBtn === void 0 ? void 0 : saveBtn.addEventListener('click', () => {
         if (!cropper)
@@ -103,8 +120,10 @@ export function openImageEditModal(fileObj) {
         ctx.drawImage(img, 0, 0);
         cropper === null || cropper === void 0 ? void 0 : cropper.destroy();
         const CropperCtor = window.Cropper || globalThis.Cropper;
-        cropper = new CropperCtor(editCanvas, { viewMode: 1 });
-        autoCropImage();
+        cropper = new CropperCtor(editCanvas, {
+            viewMode: 1,
+            ready: autoCropImage,
+        });
         URL.revokeObjectURL(url);
     };
     img.src = url;
@@ -112,6 +131,10 @@ export function openImageEditModal(fileObj) {
 }
 function closeEditor() {
     imageEditModal.style.display = 'none';
+    if (rotateHandler) {
+        editCanvas.removeEventListener('cropend', rotateHandler);
+        rotateHandler = null;
+    }
     cropper === null || cropper === void 0 ? void 0 : cropper.destroy();
     cropper = null;
 }

--- a/src/web_app/static/imageEditor.ts
+++ b/src/web_app/static/imageEditor.ts
@@ -6,6 +6,7 @@ let rotateLeftBtn: HTMLElement | null;
 let rotateRightBtn: HTMLElement | null;
 let saveBtn: HTMLElement | null;
 let cropper: any = null;
+let rotateHandler: ((e: Event) => void) | null = null;
 
 function autoCropImage() {
   if (!cropper) return;
@@ -40,13 +41,29 @@ export function setupImageEditor() {
 
   rotateLeftBtn?.addEventListener('click', () => {
     if (!cropper) return;
+    if (rotateHandler) {
+      editCanvas.removeEventListener('cropend', rotateHandler);
+    }
+    rotateHandler = () => {
+      autoCropImage();
+      editCanvas.removeEventListener('cropend', rotateHandler!);
+      rotateHandler = null;
+    };
+    editCanvas.addEventListener('cropend', rotateHandler);
     cropper.rotate(-90);
-    autoCropImage();
   });
   rotateRightBtn?.addEventListener('click', () => {
     if (!cropper) return;
+    if (rotateHandler) {
+      editCanvas.removeEventListener('cropend', rotateHandler);
+    }
+    rotateHandler = () => {
+      autoCropImage();
+      editCanvas.removeEventListener('cropend', rotateHandler!);
+      rotateHandler = null;
+    };
+    editCanvas.addEventListener('cropend', rotateHandler);
     cropper.rotate(90);
-    autoCropImage();
   });
   saveBtn?.addEventListener('click', () => {
     if (!cropper) return;
@@ -99,6 +116,10 @@ export function openImageEditModal(fileObj: { blob: Blob; name: string }) {
 
 function closeEditor() {
   imageEditModal.style.display = 'none';
+  if (rotateHandler) {
+    editCanvas.removeEventListener('cropend', rotateHandler);
+    rotateHandler = null;
+  }
   cropper?.destroy();
   cropper = null;
 }


### PR DESCRIPTION
## Summary
- Invoke `autoCropImage` after a `cropend` event so cropping occurs only after rotation completes
- Clean up temporary `cropend` handler when editor closes

## Testing
- `npx tsc`
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf4593d4c83309f0be00e9c43713b