### PR TITLE
build: regenerate imageEditor.js with ready autocrop

### DIFF
--- a/src/web_app/static/dist/imageEditor.js
+++ b/src/web_app/static/dist/imageEditor.js
@@ -103,8 +103,10 @@ export function openImageEditModal(fileObj) {
         ctx.drawImage(img, 0, 0);
         cropper === null || cropper === void 0 ? void 0 : cropper.destroy();
         const CropperCtor = window.Cropper || globalThis.Cropper;
-        cropper = new CropperCtor(editCanvas, { viewMode: 1 });
-        autoCropImage();
+        cropper = new CropperCtor(editCanvas, {
+            viewMode: 1,
+            ready: autoCropImage,
+        });
         URL.revokeObjectURL(url);
     };
     img.src = url;


### PR DESCRIPTION
## Summary
- rebuild `imageEditor.js` from TypeScript
- ensure Cropper initializes with `viewMode: 1` and calls `autoCropImage` on `ready`

## Testing
- `npm test` *(fails: Missing script "test")*
- `pytest` *(fails: ImportError: libGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf4583798833083c752a43bd00f36