### PR TITLE
fix: support running main.py without installation

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,6 +9,10 @@ from __future__ import annotations
 import logging
 import os
 import sys
+from pathlib import Path
+
+# Поддержка запуска из исходников: добавляем ``src`` в ``sys.path``
+sys.path.append(str(Path(__file__).resolve().parent / "src"))
 
 import uvicorn
 from config import LOG_LEVEL  # type: ignore


### PR DESCRIPTION
## Summary
- ensure `main.py` can load local modules by adding `src` to `sys.path`

## Testing
- `python main.py`
- `pytest` *(fails: tests/test_main_js.py::test_main_js_rotate_crop - AssertionError: Не удалось загрузить список файлов)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf75d81d08330b9a90d27804dd267