### PR TITLE
Sanitize uploaded filenames to prevent path traversal

### DIFF
--- a/src/web_app/routes/upload.py
+++ b/src/web_app/routes/upload.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 from fastapi import APIRouter, UploadFile, File, HTTPException, Form
 
-from file_sorter import place_file, get_folder_tree
+from file_sorter import place_file, get_folder_tree, sanitize_filename
 from file_utils import UnsupportedFileType
 from models import Metadata, UploadResponse
 from services.openrouter import OpenRouterError
@@ -66,9 +66,10 @@ async def upload_file(
         )
     file_id = str(uuid.uuid4())
     filename = file.filename or ""
+    filename = sanitize_filename(Path(filename).name)
     if not filename:
         guessed_ext = mimetypes.guess_extension(file.content_type or "") or ""
-        filename = f"upload{guessed_ext}"
+        filename = sanitize_filename(f"upload{guessed_ext}")
     temp_path = UPLOAD_DIR / f"{file_id}_{filename}"
     try:
         contents = await file.read()

--- a/tests/test_upload_sanitize_filename.py
+++ b/tests/test_upload_sanitize_filename.py
@@ -1,0 +1,48 @@
+import os
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+# Подключаем исходники
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+# Используем in-memory БД
+os.environ["DB_URL"] = ":memory:"
+
+from web_app import server  # noqa: E402
+from web_app.routes import upload as upload_module  # noqa: E402
+from models import Metadata  # noqa: E402
+
+
+async def _mock_generate_metadata(text, folder_tree=None, folder_index=None, file_info=None):
+    return {"metadata": Metadata(), "prompt": None, "raw_response": None}
+
+
+def _mock_extract_text(path, language="eng"):
+    return path.read_text(encoding="utf-8")
+
+
+def test_upload_path_traversal_is_sanitized(tmp_path, monkeypatch):
+    server.database.init_db()
+    server.config.output_dir = str(tmp_path / "out")
+    upload_dir = tmp_path / "uploads"
+    upload_dir.mkdir()
+    monkeypatch.setattr(upload_module, "UPLOAD_DIR", upload_dir)
+
+    secret = upload_dir / "secret.txt"
+    secret.write_text("SECRET", encoding="utf-8")
+
+    monkeypatch.setattr(server, "extract_text", _mock_extract_text)
+    monkeypatch.setattr(server.metadata_generation, "generate_metadata", _mock_generate_metadata)
+
+    with TestClient(server.app) as client:
+        resp = client.post("/upload", files={"file": ("../../secret.txt", b"payload")})
+    assert resp.status_code == 200
+    data = resp.json()
+    uploaded_path = Path(data["path"]).resolve()
+    assert uploaded_path.parent == upload_dir.resolve()
+    assert uploaded_path.name != "secret.txt"
+    assert secret.read_text(encoding="utf-8") == "SECRET"
+    assert uploaded_path.read_text(encoding="utf-8") == "payload"


### PR DESCRIPTION
## Summary
- Sanitize uploaded filenames with `Path(...).name` and `sanitize_filename` before creating paths
- Add test ensuring '../../secret.txt' uploads stay inside designated directory and don't overwrite existing files

## Testing
- `pytest tests/test_upload_sanitize_filename.py -q`
- `pytest tests/test_upload_error_handling.py tests/test_web_app.py::test_upload_retrieve_and_download -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdf8c703588330b08cd86ef7aea01f