### PR TITLE
refactor logging initialization

### DIFF
--- a/main.py
+++ b/main.py
@@ -15,7 +15,7 @@ from pathlib import Path
 sys.path.append(str(Path(__file__).resolve().parent / "src"))
 
 import uvicorn
-from config import LOG_LEVEL  # type: ignore
+from config import load_config  # type: ignore
 from logging_config import setup_logging  # type: ignore
 
 logger = logging.getLogger(__name__)
@@ -30,12 +30,14 @@ def main() -> None:
     и ``RELOAD`` (``true``/``false``, по умолчанию ``false``).
     """
 
+    cfg = load_config()
+
     host = os.getenv("HOST", "0.0.0.0")
     port = int(os.getenv("PORT", "8000"))
     reload = os.getenv("RELOAD", "false").lower() in {"1", "true", "yes"}
 
     # Настраиваем логирование согласно конфигу
-    setup_logging(LOG_LEVEL, None)
+    setup_logging(cfg.log_level, None)
     logger.info("Starting FastAPI server on %s:%s", host, port)
 
     try:

--- a/src/web_app/server.py
+++ b/src/web_app/server.py
@@ -13,10 +13,9 @@ try:
 except Exception:  # pragma: no cover
     Jinja2Templates = None  # type: ignore[misc,assignment]
 
-from config import load_config
-from logging_config import setup_logging
 from file_utils import extract_text, merge_images_to_pdf, translate_text  # noqa: F401
 import metadata_generation  # noqa: F401
+from config import config  # type: ignore
 from . import db as database
 from .routes import upload, files, folders, chat
 
@@ -51,13 +50,6 @@ async def serve_index(request: Request):
         return HTMLResponse("<h1>Docrouter</h1><p>templates/index.html не найден</p>")
     return HTMLResponse(index_path.read_text(encoding="utf-8"))
 
-
-# --------- Конфиг и логирование ----------
-config = load_config()
-try:
-    setup_logging(config.log_level, None)  # type: ignore[arg-type]
-except Exception:
-    logging.basicConfig(level=getattr(logging, str(config.log_level).upper(), logging.INFO))
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_server_import.py
+++ b/tests/test_server_import.py
@@ -1,0 +1,26 @@
+import importlib
+import sys
+
+import config
+import logging_config
+import web_app.db
+
+
+def test_server_import_has_no_side_effects(monkeypatch):
+    called = False
+
+    def fake_setup_logging(*args, **kwargs):
+        nonlocal called
+        called = True
+
+    def fake_load_config():
+        raise AssertionError("load_config should not be called during import")
+
+    monkeypatch.setattr(logging_config, "setup_logging", fake_setup_logging)
+    monkeypatch.setattr(config, "load_config", fake_load_config)
+    monkeypatch.setattr(web_app.db, "init_db", lambda force_reset=False: None)
+
+    sys.modules.pop("web_app.server", None)
+    importlib.import_module("web_app.server")
+
+    assert not called


### PR DESCRIPTION
## Summary
- remove logging setup from `web_app.server` module
- configure logging in the CLI entry point after loading config
- add regression test ensuring importing `web_app.server` has no side effects

## Testing
- `pytest -q` *(fails: tesseract OCR executable not found; Node JS script error)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf8c68ff08330a217b320db2c4549