### PR TITLE
Stream uploads in chunks and add large file test

### DIFF
--- a/src/web_app/routes/upload.py
+++ b/src/web_app/routes/upload.py
@@ -71,9 +71,12 @@ async def upload_file(
         filename = f"upload{guessed_ext}"
     temp_path = UPLOAD_DIR / f"{file_id}_{filename}"
     try:
-        contents = await file.read()
         with open(temp_path, "wb") as dest:
-            dest.write(contents)
+            while True:
+                chunk = await file.read(1024 * 1024)
+                if not chunk:
+                    break
+                dest.write(chunk)
 
         # Извлечение текста + генерация метаданных
         lang_display = language or REV_LANG_MAP.get(
@@ -173,9 +176,12 @@ async def upload_images(
     image_paths: list[Path] = []
     for idx, img in enumerate(sorted_files):
         temp_img = temp_dir / f"{idx:03d}_{img.filename}"
-        contents = await img.read()
         with open(temp_img, "wb") as dest:
-            dest.write(contents)
+            while True:
+                chunk = await img.read(1024 * 1024)
+                if not chunk:
+                    break
+                dest.write(chunk)
         image_paths.append(temp_img)
 
     try:

--- a/tests/test_upload_streaming.py
+++ b/tests/test_upload_streaming.py
@@ -1,0 +1,60 @@
+import os
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+# Используем in-memory БД
+os.environ["DB_URL"] = ":memory:"
+
+from web_app import server  # noqa: E402
+from web_app.routes import upload  # noqa: E402
+from models import Metadata  # noqa: E402
+
+app = server.app
+
+
+async def _mock_generate_metadata(text, folder_tree=None, folder_index=None):
+    """Возвращает пустые метаданные для ускорения тестов."""
+    return {"metadata": Metadata(), "prompt": "", "raw_response": ""}
+
+
+def test_large_file_processed_in_chunks(tmp_path, monkeypatch):
+    server.database.init_db()
+    server.config.output_dir = str(tmp_path)
+    monkeypatch.setattr(upload, "UPLOAD_DIR", tmp_path)
+
+    def _mock_extract_text(path, language="eng"):
+        return ""
+
+    monkeypatch.setattr(server, "extract_text", _mock_extract_text)
+    monkeypatch.setattr(
+        server.metadata_generation, "generate_metadata", _mock_generate_metadata
+    )
+
+    import starlette.datastructures as sd
+
+    call_sizes: list[int] = []
+    original_read = sd.UploadFile.read
+
+    async def tracking_read(self, size: int = -1):
+        call_sizes.append(size)
+        return await original_read(self, size)
+
+    monkeypatch.setattr(sd.UploadFile, "read", tracking_read)
+
+    big_content = b"x" * (1024 * 1024 * 2 + 12345)  # >2MB
+    with TestClient(app) as client:
+        resp = client.post("/upload", files={"file": ("big.txt", big_content)})
+
+    assert resp.status_code == 200
+    assert -1 not in call_sizes
+    assert max(call_sizes) <= 1024 * 1024
+    assert len([s for s in call_sizes if s > 0]) > 2
+
+    saved_path = Path(resp.json()["path"])
+    assert saved_path.exists()
+    assert saved_path.stat().st_size == len(big_content)


### PR DESCRIPTION
## Summary
- Stream `/upload` file writes chunk-by-chunk to reduce memory usage
- Stream image uploads before PDF merge
- Add test ensuring large files are processed in chunks

## Testing
- `pytest tests/test_upload_streaming.py -q`
- `pytest -q` *(fails: TypeError in tests/test_main_js.py: editCanvas.removeEventListener is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf8cac94c8330bc777c6aa7ed4aed