### PR TITLE
Реорганизация запуска DocRouter

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,10 @@ docker compose up --build
 
 ```bash
 pip install -e .
-python -m web_app.server
+# Запуск через модуль
+python -m docrouter
+# или через установленный скрипт
+docrouter
 ```
 
 После старта интерфейс будет доступен по адресу [http://localhost:8000](http://localhost:8000), где можно загружать, просматривать и скачивать документы.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,9 @@ dependencies = [
     "python-magic",
 ]
 
+[project.scripts]
+docrouter = "docrouter.main:main"
+
 [tool.setuptools]
 package-dir = {"" = "src"}
 py-modules = [

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,1 +1,0 @@
-# Package initializer for src

--- a/src/docrouter/__init__.py
+++ b/src/docrouter/__init__.py
@@ -1,0 +1,22 @@
+"""Package namespace for DocRouter.
+
+This module re-exports top-level modules so they can be imported via
+``docrouter`` namespace, e.g. ``from docrouter.web_app.server import app``.
+"""
+
+from importlib import import_module
+import sys as _sys
+
+# Modules and packages to expose under the ``docrouter`` namespace.
+_modules = [
+    "config",
+    "logging_config",
+    "web_app",
+]
+
+__all__ = list(_modules)
+
+for _name in _modules:
+    _module = import_module(_name)
+    _sys.modules[f"{__name__}.{_name}"] = _module
+    globals()[_name] = _module

--- a/src/docrouter/__main__.py
+++ b/src/docrouter/__main__.py
@@ -1,0 +1,6 @@
+"""CLI entry point for running DocRouter via ``python -m docrouter``."""
+
+from .main import main
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/src/docrouter/main.py
+++ b/src/docrouter/main.py
@@ -9,14 +9,11 @@ from __future__ import annotations
 import logging
 import os
 import sys
-from pathlib import Path
-
-# Поддержка запуска из исходников: добавляем ``src`` в ``sys.path``
-sys.path.append(str(Path(__file__).resolve().parent / "src"))
 
 import uvicorn
-from config import LOG_LEVEL  # type: ignore
-from logging_config import setup_logging  # type: ignore
+from docrouter.config import LOG_LEVEL  # type: ignore
+from docrouter.logging_config import setup_logging  # type: ignore
+from docrouter.web_app.server import app
 
 logger = logging.getLogger(__name__)
 
@@ -39,7 +36,7 @@ def main() -> None:
     logger.info("Starting FastAPI server on %s:%s", host, port)
 
     try:
-        uvicorn.run("web_app.server:app", host=host, port=port, reload=reload)
+        uvicorn.run(app, host=host, port=port, reload=reload)
     except Exception:
         logger.exception("Не удалось запустить сервер")
         sys.exit(1)
@@ -47,4 +44,3 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
-

--- a/tests/test_main_js.py
+++ b/tests/test_main_js.py
@@ -28,6 +28,7 @@ def test_main_js_rotate_crop(tmp_path):
           appendChild(child) { this.children.push(child); if (!this.firstChild) this.firstChild = child; return child; }
           insertBefore(node) { this.children.push(node); return node; }
           addEventListener(type, cb) { this.events[type] = cb; }
+          removeEventListener(type) { delete this.events[type]; }
           dispatchEvent(evt) { (this.events[evt.type] || (()=>{}))(evt); }
           click() { this.dispatchEvent({ type: 'click', target: this }); }
           reset() { this.value = ''; }


### PR DESCRIPTION
## Summary
- перенесён `main.py` в пакет `docrouter` и добавлены модули `__main__` и `main`
- добавлена секция `project.scripts` для запуска через `docrouter.main:main`
- обновлена документация с рекомендацией запускать `python -m docrouter` или `docrouter`
- расширен тестовый мок для поддержки `removeEventListener`

## Testing
- `pytest` *(один тест упал: tests/test_main_js.py::test_main_js_rotate_crop)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf8c1c09483308fe69195fa539d8b