### PR TITLE
fix: ensure main script finds package

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,7 +1,23 @@
 """Точка входа для запуска DocRouter как скрипта.
 
-Запускает сервер FastAPI, используя основную функцию пакета `docrouter`.
+Запускает сервер FastAPI, используя основную функцию пакета ``docrouter``.
+
+При запуске из исходников модуль ``docrouter`` может быть недоступен в
+``sys.path``. Чтобы «python main.py" работал без предварительной установки
+пакета, добавляем каталог ``src`` в путь поиска модулей.
 """
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+# Добавляем каталог ``src`` рядом с этим файлом в ``sys.path`` при необходимости
+ROOT = Path(__file__).resolve().parent
+SRC_DIR = ROOT / "src"
+if SRC_DIR.exists() and str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
 from docrouter.main import main
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add src directory to sys.path when running main.py so docrouter package is found

## Testing
- `pytest` *(fails: Module 'cv2' ... 4 failed, 58 passed, 9 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68bdff4ef358833092a287406716af0e