### PR TITLE
Добавлен confirm при подтверждении отсутствующих файлов

### DIFF
--- a/src/web_app/static/dist/uploadForm.js
+++ b/src/web_app/static/dist/uploadForm.js
@@ -72,7 +72,7 @@ export function setupUploadForm() {
                             const resp = yield fetch(`/files/${result.id}/finalize`, {
                                 method: 'POST',
                                 headers: { 'Content-Type': 'application/json' },
-                                body: JSON.stringify({ missing: result.missing || [] }),
+                                body: JSON.stringify({ missing: result.missing || [], confirm: true }),
                             });
                             if (!resp.ok)
                                 throw new Error();

--- a/src/web_app/static/uploadForm.ts
+++ b/src/web_app/static/uploadForm.ts
@@ -70,7 +70,7 @@ export function setupUploadForm() {
               const resp = await fetch(`/files/${result.id}/finalize`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ missing: result.missing || [] }),
+                body: JSON.stringify({ missing: result.missing || [], confirm: true }),
               });
               if (!resp.ok) throw new Error();
               const finalData = await resp.json();


### PR DESCRIPTION
## Summary
- добавлен флаг `confirm: true` при отправке запроса `finalize`
- пересобран фронтенд

## Testing
- `npx tsc`
- `pytest` *(fails: renderTree is not a function, Не удалось загрузить список файлов, KeyError: 'language', assert 500 == 200, assert 503 == 200)*

------
https://chatgpt.com/codex/tasks/task_e_68be04075a3c8330a4b65fc49b80cb29