### PR TITLE
Add database close function and shutdown hook

### DIFF
--- a/src/web_app/db.py
+++ b/src/web_app/db.py
@@ -74,6 +74,16 @@ def init_db(force_reset: bool | None = None) -> None:
         )
 
 
+def close_db() -> None:
+    """Закрыть соединение с БД и сбросить ссылку."""
+    global _conn
+    if _conn is not None:
+        try:
+            _conn.close()
+        finally:
+            _conn = None
+
+
 def _serialize_record(record: FileRecord) -> Dict[str, Any]:
     return {
         "id": record.id,

--- a/src/web_app/server.py
+++ b/src/web_app/server.py
@@ -56,6 +56,11 @@ logger = logging.getLogger(__name__)
 # --------- Инициализация БД ----------
 database.init_db(force_reset=os.getenv("DOCROUTER_RESET_DB") == "1")
 
+
+@app.on_event("shutdown")
+def _shutdown() -> None:
+    database.close_db()
+
 # --------- Подключение маршрутов ----------
 app.include_router(upload.router)
 app.include_router(files.router)

--- a/tests/test_db_reopen.py
+++ b/tests/test_db_reopen.py
@@ -1,0 +1,28 @@
+import sqlite3
+import web_app.db as db
+import pytest
+
+
+def test_close_and_reopen_db(tmp_path):
+    original_path = db._DB_PATH
+    original_conn = db._conn
+    try:
+        db._DB_PATH = tmp_path / "test.sqlite"
+        db._conn = None
+        db.init_db()
+        conn1 = db._conn
+        assert conn1 is not None
+
+        db.close_db()
+        assert db._conn is None
+        with pytest.raises(sqlite3.ProgrammingError):
+            conn1.execute("SELECT 1")
+
+        db.init_db()
+        conn2 = db._conn
+        assert conn2 is not None
+        assert conn2 is not conn1
+    finally:
+        db.close_db()
+        db._DB_PATH = original_path
+        db._conn = original_conn

--- a/tests/test_finalize_file.py
+++ b/tests/test_finalize_file.py
@@ -49,11 +49,11 @@ def test_finalize_file_moves_and_creates_metadata(tmp_path, monkeypatch):
         )
         assert finalize_resp.status_code == 200
         dest_path = Path(finalize_resp.json()["path"])
+        record = server.database.get_file(file_id)
 
     assert dest_path.exists()
     assert not temp_path.exists()
     assert dest_path.with_suffix(dest_path.suffix + ".json").exists()
 
-    record = server.database.get_file(file_id)
     assert record is not None
     assert record.status == "processed"

--- a/tests/test_folder_tree.py
+++ b/tests/test_folder_tree.py
@@ -25,6 +25,7 @@ def test_get_folder_tree_returns_name_children(tmp_path):
 def test_folder_tree_endpoint(tmp_path):
     (tmp_path / "X" / "Y").mkdir(parents=True)
     server.config.output_dir = str(tmp_path)
+    server.database.init_db()
     client = TestClient(server.app)
     resp = client.get("/folder-tree")
     assert resp.status_code == 200

--- a/tests/test_folder_tree_route.py
+++ b/tests/test_folder_tree_route.py
@@ -53,6 +53,7 @@ def test_folder_tree_includes_files(tmp_path):
     (person / "file1.txt").write_text("content", encoding="utf-8")
 
     server.config.output_dir = str(tmp_path)
+    server.database.init_db()
 
     with LiveClient(app) as client:
         resp = client.get("/folder-tree")

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -103,10 +103,12 @@ def test_upload_retrieve_and_download(tmp_path, monkeypatch):
             return f.read()
 
     import file_utils, sys
-    monkeypatch.setattr(server, "extract_text", _mock_extract_text)
-    monkeypatch.setattr(file_utils, "extract_text", _mock_extract_text)
-    monkeypatch.setattr(server.metadata_generation, "generate_metadata", _mock_generate_metadata)
-    sys.modules["web_app.server"] = server
+    monkeypatch.setattr("web_app.server.extract_text", _mock_extract_text)
+    monkeypatch.setattr("file_utils.extract_text", _mock_extract_text)
+    monkeypatch.setattr(
+        "web_app.server.metadata_generation.generate_metadata", _mock_generate_metadata
+    )
+    server.database.init_db()
     server.config.output_dir = str(tmp_path)
     (tmp_path / "John Doe").mkdir()
 
@@ -209,8 +211,6 @@ def test_translation_error_returns_502(tmp_path, monkeypatch):
 
 
 def test_upload_images_returns_sources(tmp_path, monkeypatch):
-    server.database.init_db()
-
     captured = {}
 
     def _mock_merge(paths):
@@ -224,12 +224,14 @@ def test_upload_images_returns_sources(tmp_path, monkeypatch):
         return "pdf text"
 
     import file_utils, sys
-    monkeypatch.setattr(server, "merge_images_to_pdf", _mock_merge)
-    monkeypatch.setattr(file_utils, "merge_images_to_pdf", _mock_merge)
-    monkeypatch.setattr(server, "extract_text", _mock_extract_text)
-    monkeypatch.setattr(file_utils, "extract_text", _mock_extract_text)
-    monkeypatch.setattr(server.metadata_generation, "generate_metadata", _mock_generate_metadata)
-    sys.modules["web_app.server"] = server
+    monkeypatch.setattr("web_app.server.merge_images_to_pdf", _mock_merge)
+    monkeypatch.setattr("file_utils.merge_images_to_pdf", _mock_merge)
+    monkeypatch.setattr("web_app.server.extract_text", _mock_extract_text)
+    monkeypatch.setattr("file_utils.extract_text", _mock_extract_text)
+    monkeypatch.setattr(
+        "web_app.server.metadata_generation.generate_metadata", _mock_generate_metadata
+    )
+    server.database.init_db()
     server.config.output_dir = str(tmp_path)
     (tmp_path / "John Doe").mkdir()
 
@@ -256,8 +258,6 @@ def test_upload_images_returns_sources(tmp_path, monkeypatch):
 
 
 def test_upload_images_download_and_metadata(tmp_path, monkeypatch):
-    server.database.init_db()
-
     captured = {}
 
     pdf_bytes = b"PDF"
@@ -273,12 +273,14 @@ def test_upload_images_download_and_metadata(tmp_path, monkeypatch):
         return "page1\npage2"
 
     import file_utils, sys
-    monkeypatch.setattr(server, "merge_images_to_pdf", _mock_merge)
-    monkeypatch.setattr(file_utils, "merge_images_to_pdf", _mock_merge)
-    monkeypatch.setattr(server, "extract_text", _mock_extract_text)
-    monkeypatch.setattr(file_utils, "extract_text", _mock_extract_text)
-    monkeypatch.setattr(server.metadata_generation, "generate_metadata", _mock_generate_metadata)
-    sys.modules["web_app.server"] = server
+    monkeypatch.setattr("web_app.server.merge_images_to_pdf", _mock_merge)
+    monkeypatch.setattr("file_utils.merge_images_to_pdf", _mock_merge)
+    monkeypatch.setattr("web_app.server.extract_text", _mock_extract_text)
+    monkeypatch.setattr("file_utils.extract_text", _mock_extract_text)
+    monkeypatch.setattr(
+        "web_app.server.metadata_generation.generate_metadata", _mock_generate_metadata
+    )
+    server.database.init_db()
     server.config.output_dir = str(tmp_path)
     (tmp_path / "John Doe").mkdir()
 


### PR DESCRIPTION
## Summary
- implement `close_db` to safely close and reset SQLite connection
- register FastAPI `shutdown` handler to close DB on server stop
- add tests ensuring connection closes and reopens correctly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68be0c41c20483309c4f1d83edd80f23