### PR TITLE
Handle translation HTTP errors

### DIFF
--- a/src/web_app/routes/files.py
+++ b/src/web_app/routes/files.py
@@ -144,7 +144,7 @@ async def download_file(file_id: str, lang: str | None = None):
         else:
             try:
                 text = await server.translate_text(extracted, lang)
-            except httpx.HTTPError as e:
+            except (httpx.HTTPError, RuntimeError) as e:
                 raise HTTPException(
                     status_code=502,
                     detail="Translation service unavailable",
@@ -192,7 +192,7 @@ async def get_file_details(file_id: str, lang: str | None = None):
         else:
             try:
                 text = await server.translate_text(extracted, lang)
-            except httpx.HTTPError as e:
+            except (httpx.HTTPError, RuntimeError) as e:
                 raise HTTPException(
                     status_code=502,
                     detail="Translation service unavailable",


### PR DESCRIPTION
## Summary
- wrap OpenRouter translation call in try/except and rethrow RuntimeError with logging
- handle translation RuntimeError in file download and detail routes

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic_settings'; NameError: name 'LOADER_DIR' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68be0f320f948330a8096db9a4a2d627