### PR TITLE
refactor: default confirm callback rejects path creation

### DIFF
--- a/src/file_sorter.py
+++ b/src/file_sorter.py
@@ -127,13 +127,17 @@ def get_folder_tree(
     return tree, index
 
 
+def _reject_paths(_: List[str]) -> bool:
+    return False
+
+
 def place_file(
     src_path: str | Path,
     metadata: Dict[str, Any],
     dest_root: str | Path,
     dry_run: bool = False,
     needs_new_folder: bool = False,
-    confirm_callback: Callable[[List[str]], bool] | None = None,
+    confirm_callback: Callable[[List[str]], bool] = _reject_paths,
 ) -> Tuple[Path, List[str], bool]:
     """Переместить файл в структуру папок на основе *metadata*.
 
@@ -243,9 +247,6 @@ def place_file(
         logger.info("Would write metadata JSON to %s", json_file)
         return dest_file, missing, confirmed
 
-    if confirm_callback is None:
-        confirm_callback = lambda _paths: False  # type: ignore[assignment]
-
     # Создаём недостающие каталоги только при подтверждении
     if missing and needs_new_folder:
         confirmed = bool(confirm_callback(missing))
@@ -298,6 +299,5 @@ def preview_destination(
         dest_root,
         dry_run=True,
         needs_new_folder=needs_new_folder,
-        confirm_callback=None,
     )
     return dest, missing


### PR DESCRIPTION
## Summary
- add `_reject_paths` helper and use as default confirmation callback
- remove `None` check inside `place_file`
- drop explicit `confirm_callback=None` when previewing destination

## Testing
- `pytest` *(fails: NameError: name 'LOADER_DIR' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68be0f2e02ac83309182a704077b90e7