### PR TITLE
Run database operations in background threads

### DIFF
--- a/src/web_app/db.py
+++ b/src/web_app/db.py
@@ -6,12 +6,18 @@ from pathlib import Path
 import json
 import os
 import sqlite3
+import asyncio
 from typing import Any, Dict, List, Optional
 
 from models import FileRecord, Metadata
 
 _DB_PATH = Path(__file__).with_suffix(".sqlite")
 _conn: sqlite3.Connection | None = None
+
+
+async def run_db(func, *args, **kwargs):
+    """Запустить синхронную функцию работы с БД в отдельном потоке."""
+    return await asyncio.to_thread(func, *args, **kwargs)
 
 
 def _get_conn() -> sqlite3.Connection:

--- a/src/web_app/routes/folders.py
+++ b/src/web_app/routes/folders.py
@@ -5,6 +5,7 @@ from fastapi import APIRouter, HTTPException
 
 from file_sorter import get_folder_tree
 from .. import server, db as database
+from ..db import run_db
 
 router = APIRouter()
 
@@ -25,7 +26,8 @@ async def folder_tree() -> List[dict[str, Any]]:
 
     # Сопоставим пути файлов с их идентификаторами из БД, чтобы на фронте
     # можно было обращаться к существующим маршрутам просмотра/скачивания.
-    id_map = {Path(rec.path).resolve(): rec.id for rec in database.list_files()}
+    records = await run_db(database.list_files)
+    id_map = {Path(rec.path).resolve(): rec.id for rec in records}
 
     def attach_ids(nodes):
         for node in nodes:

--- a/src/web_app/routes/upload.py
+++ b/src/web_app/routes/upload.py
@@ -15,6 +15,7 @@ from file_utils import UnsupportedFileType
 from models import Metadata, UploadResponse
 from services.openrouter import OpenRouterError
 from .. import db as database
+from ..db import run_db
 from config import config
 
 router = APIRouter()
@@ -130,7 +131,8 @@ async def upload_file(
         logger.exception("Upload/processing failed for %s", filename)
         raise HTTPException(status_code=500, detail=str(exc)) from exc
 
-    database.add_file(
+    await run_db(
+        database.add_file,
         file_id,
         file.filename,
         metadata,
@@ -245,7 +247,8 @@ async def upload_images(
 
     sources = [f.filename for f in sorted_files]
 
-    database.add_file(
+    await run_db(
+        database.add_file,
         file_id,
         pdf_path.name,
         metadata,

--- a/tests/test_files_scan_cache.py
+++ b/tests/test_files_scan_cache.py
@@ -15,9 +15,11 @@ def test_list_files_uses_cache(monkeypatch, tmp_path):
     upload_dir.mkdir()
     monkeypatch.setattr(files_module, "UPLOAD_DIR", upload_dir)
 
+    server.database.init_db()
+
     calls = {"n": 0}
 
-    def fake_scan():
+    async def fake_scan():
         calls["n"] += 1
 
     monkeypatch.setattr(files_module, "_scan_output_dir", fake_scan)

--- a/tests/test_scan_output_dir.py
+++ b/tests/test_scan_output_dir.py
@@ -1,5 +1,6 @@
 import sys
 from pathlib import Path
+import asyncio
 
 import pytest
 
@@ -21,7 +22,7 @@ def test_scan_output_dir_updates_on_rename(tmp_path, monkeypatch):
     file = out_dir / "doc.txt"
     file.write_text("content")
 
-    _scan_output_dir()
+    asyncio.run(_scan_output_dir())
     records = server.database.list_files()
     assert len(records) == 1
     file_id = records[0].id
@@ -29,7 +30,7 @@ def test_scan_output_dir_updates_on_rename(tmp_path, monkeypatch):
     new_path = out_dir / "renamed.txt"
     file.rename(new_path)
 
-    _scan_output_dir()
+    asyncio.run(_scan_output_dir())
     records = server.database.list_files()
     assert len(records) == 1
     record = records[0]


### PR DESCRIPTION
## Summary
- add `run_db` helper using `asyncio.to_thread`
- call `await run_db(...)` for all DB reads and writes in web routes
- adapt tests for async DB helpers

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68be10d0aecc8330981eb1b375e410ae