### PR TITLE
ignore unknown environment variables

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -8,7 +8,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 class Config(BaseSettings):
     """Configuration settings for the application."""
 
-    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", extra="ignore")
 
     log_level: str = "INFO"
     tesseract_lang: str = "eng"

--- a/tests/test_config_ignore_unknown.py
+++ b/tests/test_config_ignore_unknown.py
@@ -1,0 +1,15 @@
+import pytest
+
+pytest.importorskip("dotenv")
+
+from config import Config
+
+
+def test_ignore_unknown_env_vars(tmp_path):
+    env_file = tmp_path / ".env"
+    env_file.write_text("UNKNOWN_VAR=1\nLOG_LEVEL=DEBUG\n", encoding="utf-8")
+
+    cfg = Config(_env_file=env_file)
+
+    assert cfg.log_level == "DEBUG"
+    assert not hasattr(cfg, "unknown_var")


### PR DESCRIPTION
## Summary
- allow config to ignore unused environment variables
- test config loading when extra variables are present

## Testing
- `PYTHONPATH=src EXTRA_VAR=1 python -c "from config import Config; Config(); print('ok')"`
- `PYTHONPATH=src pytest tests/test_config_env_priority.py tests/test_config_ignore_unknown.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68be15087b808330b5c7f8efc7276eef