### PR TITLE
feat: lazy load heavy modules and async startup

### DIFF
--- a/src/file_utils/__init__.py
+++ b/src/file_utils/__init__.py
@@ -288,13 +288,14 @@ __all__ = [
     "translate_text",
 ]
 
+def load_plugins() -> None:
+    """Явно загрузить плагины file_utils."""
+    try:
+        from plugins import load_plugins as _load_plugins
 
-try:  # Автообнаружение плагинов
-    from plugins import load_plugins as _load_plugins
-
-    _load_plugins()
-except Exception:  # pragma: no cover - отсутствие плагинов не критично
-    logger.debug("Plugin loading skipped", exc_info=True)
+        _load_plugins()
+    except Exception:  # pragma: no cover - отсутствие плагинов не критично
+        logger.debug("Plugin loading skipped", exc_info=True)
 
 
 async def translate_text(

--- a/src/web_app/routes/upload.py
+++ b/src/web_app/routes/upload.py
@@ -11,7 +11,6 @@ from pathlib import Path
 from fastapi import APIRouter, UploadFile, File, HTTPException, Form
 
 from file_sorter import place_file, get_folder_tree, sanitize_filename
-from file_utils import UnsupportedFileType
 from models import Metadata, UploadResponse
 from services.openrouter import OpenRouterError
 from .. import db as database
@@ -62,6 +61,7 @@ async def process_uploaded(
 ) -> tuple[Metadata, Path, list[str], dict]:
     """Обработать загруженный файл и вернуть метаданные."""
     from .. import server
+    from file_utils import UnsupportedFileType
 
     lang_display = language or REV_LANG_MAP.get(
         server.config.tesseract_lang, server.config.tesseract_lang


### PR DESCRIPTION
## Summary
- make startup async and init database in thread
- defer heavy imports and plugin loading
- import file_utils errors lazily

## Testing
- `pytest` *(fails: OCR binary tesseract not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68be160c841883308e5936548e7f8642