### PR TITLE
refactor: lazy imports and plugin loading

### DIFF
--- a/src/file_utils/__init__.py
+++ b/src/file_utils/__init__.py
@@ -286,15 +286,21 @@ __all__ = [
     "merge_images_to_pdf",
     "parse_mrz",
     "translate_text",
+    "load_plugins",
 ]
 
-
-try:  # Автообнаружение плагинов
-    from plugins import load_plugins as _load_plugins
-
-    _load_plugins()
-except Exception:  # pragma: no cover - отсутствие плагинов не критично
-    logger.debug("Plugin loading skipped", exc_info=True)
+def load_plugins() -> None:
+    """Автоматически обнаружить и загрузить плагины, если они доступны."""
+    try:
+        import importlib
+        plugin_module = importlib.import_module("plugins")
+    except Exception:  # pragma: no cover - отсутствие плагинов не критично
+        logger.debug("Plugin module not found", exc_info=True)
+        return
+    try:
+        plugin_module.load_plugins()  # type: ignore[attr-defined]
+    except Exception:  # pragma: no cover - ошибки плагинов не критичны
+        logger.warning("Plugin loading failed", exc_info=True)
 
 
 async def translate_text(

--- a/src/web_app/routes/files.py
+++ b/src/web_app/routes/files.py
@@ -224,6 +224,7 @@ async def get_file_details(file_id: str, lang: str | None = None):
             record.translation_lang = lang
         record.translated_text = record.translated_text or text
         record.translation_lang = lang
+    record.sources = None
     return record
 
 

--- a/src/web_app/server.py
+++ b/src/web_app/server.py
@@ -8,14 +8,14 @@ from fastapi import FastAPI, Request
 from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 import uvicorn
+import threading
+import importlib
 try:
     from fastapi.templating import Jinja2Templates
 except Exception:  # pragma: no cover
     Jinja2Templates = None  # type: ignore[misc,assignment]
 
-from file_utils import extract_text, merge_images_to_pdf, translate_text  # noqa: F401
-import metadata_generation  # noqa: F401
-from config import config  # type: ignore
+from config import config  # type: ignore  # noqa: F401
 from . import db as database
 from .routes import upload, files, folders, chat
 
@@ -53,6 +53,16 @@ async def serve_index(request: Request):
 
 logger = logging.getLogger(__name__)
 
+
+def __getattr__(name: str):
+    """Лениво импортировать тяжёлые зависимости при обращении."""
+    if name in {"extract_text", "merge_images_to_pdf", "translate_text"}:
+        utils = importlib.import_module("file_utils")
+        return getattr(utils, name)
+    if name == "metadata_generation":
+        return importlib.import_module("metadata_generation")
+    raise AttributeError(f"module {__name__} has no attribute {name}")
+
 # --------- Инициализация БД ----------
 
 
@@ -60,6 +70,15 @@ logger = logging.getLogger(__name__)
 def startup() -> None:
     """Инициализировать базу данных перед обработкой запросов."""
     database.init_db()
+
+    def _load_plugins() -> None:
+        try:
+            file_utils = importlib.import_module("file_utils")
+            file_utils.load_plugins()
+        except Exception:  # pragma: no cover - ошибки плагинов не критичны
+            logger.warning("Plugin loading failed", exc_info=True)
+
+    threading.Thread(target=_load_plugins, name="plugin-loader", daemon=True).start()
 
 
 @app.on_event("shutdown")


### PR DESCRIPTION
## Summary
- remove heavy file_utils and metadata_generation imports from server and load them lazily
- add explicit load_plugins() in file_utils and run plugin loading in background
- hide file sources in details endpoint

## Testing
- `TESSERACT_CMD=/bin/true pytest`

------
https://chatgpt.com/codex/tasks/task_e_68be168d2c7883308d32d8abd757d9b6