### PR TITLE
refactor: lazy-load docrouter submodules

### DIFF
--- a/src/docrouter/__init__.py
+++ b/src/docrouter/__init__.py
@@ -1,9 +1,13 @@
 """Package for DocRouter CLI and submodules."""
+
 from importlib import import_module as _import_module
+from pathlib import Path as _Path
 import sys as _sys
 
-# Expose top-level modules under the docrouter namespace for compatibility
-for _name in [
+# Allow using top-level modules under the ``docrouter`` namespace lazily.
+__path__.append(str(_Path(__file__).resolve().parent.parent))
+
+_SUPPORTED_MODULES = {
     "config",
     "error_handling",
     "file_sorter",
@@ -17,7 +21,16 @@ for _name in [
     "plugins",
     "web_app",
     "logging_config",
-]:
-    _sys.modules[f"{__name__}.{_name}"] = _import_module(_name)
+}
+
+
+def __getattr__(name: str):  # pragma: no cover - thin wrapper
+    """Dynamically import supported modules on first access."""
+    if name in _SUPPORTED_MODULES:
+        module = _import_module(name)
+        _sys.modules[f"{__name__}.{name}"] = module
+        return module
+    raise AttributeError(f"module {__name__} has no attribute {name}")
+
 
 __all__ = ["main"]


### PR DESCRIPTION
## Summary
- avoid importing heavy modules on package load by removing eager import loop
- expose top-level modules lazily via `__getattr__`

## Testing
- `PYTHONPATH=src python - <<'PY' import importlib
modules = ["docrouter","docrouter.config","docrouter.logging_config","docrouter.web_app.server","docrouter.main"]
for m in modules: importlib.import_module(m)
print("ok")
PY`
- `PYTHONPATH=src python - <<'PY' import docrouter
from docrouter import file_utils
print('module', file_utils.__name__)
PY`
- `PYTHONPATH=src pytest` *(fails: tests/test_upload_dry_run.py::test_upload_dry_run_keeps_file - assert 502 == 200, tests/test_upload_sanitize_filename.py::test_upload_path_traversal_is_sanitized - assert 502 == 200, tests/test_upload_streaming.py::test_large_file_processed_in_chunks - assert 502 == 200, tests/test_web_app.py::test_translation_error_returns_502 - assert 502 == 200, tests/test_web_app.py::test_details_endpoint_returns_full_record - assert 502 == 200)*

------
https://chatgpt.com/codex/tasks/task_e_68be1a669cb883308c4accf4f296313b