### PR TITLE
refactor: delay plugin loading in metadata generation

### DIFF
--- a/src/metadata_generation.py
+++ b/src/metadata_generation.py
@@ -327,10 +327,3 @@ async def generate_metadata(
         "metadata": metadata_model,
     }
 
-
-# Автообнаружение плагинов (не критично, падать не будем)
-try:
-    from plugins import load_plugins as _load_plugins
-    _load_plugins()
-except Exception:  # pragma: no cover
-    logger.debug("Plugin loading skipped", exc_info=True)

--- a/src/web_app/server.py
+++ b/src/web_app/server.py
@@ -117,6 +117,8 @@ async def startup() -> None:
     def _load_plugins() -> None:
         try:
             _load_file_utils().load_plugins()
+            from plugins import load_plugins as _load_plugins
+            _load_plugins()
         except Exception:  # pragma: no cover - плагины не обязательны
             logger.debug("Plugin loading skipped", exc_info=True)
 


### PR DESCRIPTION
## Summary
- remove plugin auto-loading from `metadata_generation`
- load plugins explicitly during FastAPI startup

## Testing
- `pytest -q` *(fails: OPENROUTER_API_KEY environment variable required)*

------
https://chatgpt.com/codex/tasks/task_e_68be1a66e68c83309e390cbb86c57f91