### PR TITLE
Fix duplicate record addition on refresh

### DIFF
--- a/src/web_app/routes/files.py
+++ b/src/web_app/routes/files.py
@@ -77,6 +77,8 @@ async def _scan_output_dir() -> None:
         if file_path.suffix == ".json":
             doc_path = file_path.with_suffix("")
             if not doc_path.exists():
+                if doc_path in existing_paths:
+                    continue
                 metadata = Metadata()
                 try:
                     meta_dict = json.loads(file_path.read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary
- skip adding records for missing documents that are already in the database

## Testing
- `pytest` (fails: test_upload_dry_run.py::test_upload_dry_run_keeps_file, test_upload_sanitize_filename.py::test_upload_path_traversal_is_sanitized, test_upload_streaming.py::test_large_file_processed_in_chunks, test_web_app.py::test_translation_error_returns_502, test_web_app.py::test_details_endpoint_returns_full_record)


------
https://chatgpt.com/codex/tasks/task_e_68c037a0f62883308adeafc40b382296