### PR TITLE
Handle missing OpenRouter API key gracefully

### DIFF
--- a/tests/test_metadata_generation.py
+++ b/tests/test_metadata_generation.py
@@ -6,7 +6,6 @@ import pytest
 
 from metadata_generation import generate_metadata, MetadataAnalyzer
 from file_sorter import build_folder_index
-from services.openrouter import OpenRouterError
 from models import Metadata
 
 
@@ -23,8 +22,10 @@ class DummyAnalyzer(MetadataAnalyzer):
 
 def test_generate_metadata_without_api_key(monkeypatch):
     monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
-    with pytest.raises(OpenRouterError):
-        asyncio.run(generate_metadata("text"))
+    monkeypatch.setattr("metadata_generation.OPENROUTER_API_KEY", None, raising=False)
+    result = asyncio.run(generate_metadata("text"))
+    meta: Metadata = result["metadata"]
+    assert meta.category is None
 
 
 def test_prompt_includes_context(monkeypatch):

--- a/tests/test_upload_dry_run.py
+++ b/tests/test_upload_dry_run.py
@@ -29,6 +29,7 @@ def test_upload_dry_run_keeps_file(tmp_path, monkeypatch):
     asyncio.run(server.database.run_db(server.database.init_db))
     out_dir = tmp_path / "out"
     (out_dir / "John Doe").mkdir(parents=True)
+    (out_dir / "Shared").mkdir(parents=True)
     server.config.output_dir = str(out_dir)
 
     upload_dir = tmp_path / "uploads"

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -332,6 +332,7 @@ def test_details_endpoint_returns_full_record(tmp_path, monkeypatch):
     monkeypatch.setattr(server.metadata_generation, "generate_metadata", _mock_generate_metadata)
     server.config.output_dir = str(tmp_path)
     (tmp_path / "John Doe").mkdir()
+    (tmp_path / "Shared").mkdir()
 
     with LiveClient(app) as client:
         resp = client.post(
@@ -360,5 +361,5 @@ def test_details_endpoint_returns_full_record(tmp_path, monkeypatch):
         expected["confirmed"] = False
         expected["created_path"] = None
         expected["review_comment"] = None
-        expected["sources"] = data["sources"]
+        expected["sources"] = None
     assert details_json == expected


### PR DESCRIPTION
## Summary
- Add `NoOpAnalyzer` fallback when `OPENROUTER_API_KEY` is absent
- Skip metadata generation without API key and adjust tests accordingly

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c073fa0ac48330907b75474b1b07e0