### PR TITLE
feat: add AI chat option in confirmation modal

### DIFF
--- a/src/web_app/static/chat.ts
+++ b/src/web_app/static/chat.ts
@@ -34,6 +34,11 @@ export function setupChat() {
       const data = (await resp.json()) as { chat_history: ChatHistory[] };
       renderChat(data.chat_history);
       chatInput.value = '';
+      document.dispatchEvent(
+        new CustomEvent('chat-updated', {
+          detail: { id: currentChatId, history: data.chat_history },
+        })
+      );
     } catch {
       showNotification('Ошибка отправки сообщения');
     }
@@ -54,7 +59,13 @@ export async function openChatModal(file: FileInfo) {
   try {
     const resp = await apiRequest(`/files/${file.id}/details`);
     const data = (await resp.json()) as FileInfo;
-    renderChat((data as any)?.chat_history || []);
+    const history = (data as any)?.chat_history || [];
+    renderChat(history);
+    document.dispatchEvent(
+      new CustomEvent('chat-updated', {
+        detail: { id: currentChatId, history },
+      })
+    );
   } catch {
     renderChat([]);
     showNotification('Не удалось загрузить чат');

--- a/src/web_app/static/dist/chat.js
+++ b/src/web_app/static/dist/chat.js
@@ -38,6 +38,9 @@ export function setupChat() {
             const data = (yield resp.json());
             renderChat(data.chat_history);
             chatInput.value = '';
+            document.dispatchEvent(new CustomEvent('chat-updated', {
+                detail: { id: currentChatId, history: data.chat_history },
+            }));
         }
         catch (_a) {
             showNotification('Ошибка отправки сообщения');
@@ -58,7 +61,11 @@ export function openChatModal(file) {
         try {
             const resp = yield apiRequest(`/files/${file.id}/details`);
             const data = (yield resp.json());
-            renderChat((data === null || data === void 0 ? void 0 : data.chat_history) || []);
+            const history = (data === null || data === void 0 ? void 0 : data.chat_history) || [];
+            renderChat(history);
+            document.dispatchEvent(new CustomEvent('chat-updated', {
+                detail: { id: currentChatId, history },
+            }));
         }
         catch (_a) {
             renderChat([]);


### PR DESCRIPTION
## Summary
- add Ask AI button in confirmation step modal and wire to chat
- propagate chat answers back to modal dialog via chat-updated event

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c07a2e04248330a838899a65c733bc