### PR TITLE
feat: regenerate file metadata

### DIFF
--- a/src/web_app/static/dist/files.js
+++ b/src/web_app/static/dist/files.js
@@ -246,6 +246,21 @@ export function refreshFiles() {
                     openChatModal(f);
                 });
                 actionsTd.appendChild(chatBtn);
+                const regenBtn = document.createElement('button');
+                regenBtn.type = 'button';
+                regenBtn.textContent = 'Перегенерировать';
+                regenBtn.addEventListener('click', (ev) => __awaiter(this, void 0, void 0, function* () {
+                    ev.stopPropagation();
+                    try {
+                        yield apiRequest(`/files/${f.id}/regenerate`, { method: 'POST' });
+                        showNotification('Метаданные обновлены');
+                        yield refreshFiles();
+                    }
+                    catch (_a) {
+                        showNotification('Ошибка генерации');
+                    }
+                }));
+                actionsTd.appendChild(regenBtn);
                 tr.appendChild(actionsTd);
                 list.appendChild(tr);
             });

--- a/src/web_app/static/dist/uploadForm.js
+++ b/src/web_app/static/dist/uploadForm.js
@@ -97,10 +97,8 @@ export function setupUploadForm() {
         if (!currentId)
             return;
         try {
-            const resp = yield fetch(`/files/${currentId}/comment`, {
+            const resp = yield fetch(`/files/${currentId}/regenerate`, {
                 method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ message: '' }),
             });
             if (!resp.ok)
                 throw new Error();

--- a/src/web_app/static/files.ts
+++ b/src/web_app/static/files.ts
@@ -255,6 +255,21 @@ export async function refreshFiles(force = false, q = '') {
       });
       actionsTd.appendChild(chatBtn);
 
+      const regenBtn = document.createElement('button');
+      regenBtn.type = 'button';
+      regenBtn.textContent = 'Перегенерировать';
+      regenBtn.addEventListener('click', async (ev) => {
+        ev.stopPropagation();
+        try {
+          await apiRequest(`/files/${f.id}/regenerate`, { method: 'POST' });
+          showNotification('Метаданные обновлены');
+          await refreshFiles();
+        } catch {
+          showNotification('Ошибка генерации');
+        }
+      });
+      actionsTd.appendChild(regenBtn);
+
       tr.appendChild(actionsTd);
       list.appendChild(tr);
     });

--- a/src/web_app/static/uploadForm.ts
+++ b/src/web_app/static/uploadForm.ts
@@ -97,10 +97,8 @@ export function setupUploadForm() {
   regenerateBtn.addEventListener('click', async () => {
     if (!currentId) return;
     try {
-      const resp = await fetch(`/files/${currentId}/comment`, {
+      const resp = await fetch(`/files/${currentId}/regenerate`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ message: '' }),
       });
       if (!resp.ok) throw new Error();
       const data = await resp.json();


### PR DESCRIPTION
## Summary
- add `/files/{file_id}/regenerate` endpoint for metadata regeneration
- wire up regenerate button in UI to call new endpoint

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c07a2b077c83308143bbc88127179c