### PR TITLE
feat: enrich frontend types with review metadata

### DIFF
--- a/src/web_app/static/chat.ts
+++ b/src/web_app/static/chat.ts
@@ -56,15 +56,22 @@ function renderChat(history: ChatHistory[]) {
 
 export async function openChatModal(file: FileInfo) {
   currentChatId = file.id;
-  try {
-    const resp = await apiRequest(`/files/${file.id}/details`);
-    const data = (await resp.json()) as FileInfo;
-    const history = (data as any)?.chat_history || [];
+  const history = file.chat_history && file.chat_history.length ? file.chat_history : null;
+  if (history) {
     renderChat(history);
     document.dispatchEvent(
-      new CustomEvent('chat-updated', {
-        detail: { id: currentChatId, history },
-      })
+      new CustomEvent('chat-updated', { detail: { id: currentChatId, history } })
+    );
+    openModal(chatModal);
+    return;
+  }
+  try {
+    const resp = await apiRequest(`/files/${file.id}/details`);
+    const data: FileInfo = await resp.json();
+    const hist = data.chat_history || [];
+    renderChat(hist);
+    document.dispatchEvent(
+      new CustomEvent('chat-updated', { detail: { id: currentChatId, history: hist } })
     );
   } catch {
     renderChat([]);

--- a/src/web_app/static/dist/chat.js
+++ b/src/web_app/static/dist/chat.js
@@ -58,14 +58,19 @@ function renderChat(history) {
 export function openChatModal(file) {
     return __awaiter(this, void 0, void 0, function* () {
         currentChatId = file.id;
+        const history = file.chat_history && file.chat_history.length ? file.chat_history : null;
+        if (history) {
+            renderChat(history);
+            document.dispatchEvent(new CustomEvent('chat-updated', { detail: { id: currentChatId, history } }));
+            openModal(chatModal);
+            return;
+        }
         try {
             const resp = yield apiRequest(`/files/${file.id}/details`);
-            const data = (yield resp.json());
-            const history = (data === null || data === void 0 ? void 0 : data.chat_history) || [];
-            renderChat(history);
-            document.dispatchEvent(new CustomEvent('chat-updated', {
-                detail: { id: currentChatId, history },
-            }));
+            const data = yield resp.json();
+            const hist = data.chat_history || [];
+            renderChat(hist);
+            document.dispatchEvent(new CustomEvent('chat-updated', { detail: { id: currentChatId, history: hist } }));
         }
         catch (_a) {
             renderChat([]);

--- a/src/web_app/static/dist/imageBatch.js
+++ b/src/web_app/static/dist/imageBatch.js
@@ -70,7 +70,7 @@ export function uploadEditedImages() {
         const resp = yield fetch('/upload/images', { method: 'POST', body: data });
         if (resp.ok) {
             const result = yield resp.json();
-            renderDialog(aiExchange, result.prompt, result.raw_response);
+            renderDialog(aiExchange, result.prompt, result.raw_response, result.chat_history, result.review_comment, result.created_path);
             imageFiles = [];
             currentImageIndex = -1;
             fileInput.value = '';

--- a/src/web_app/static/folders.ts
+++ b/src/web_app/static/folders.ts
@@ -55,6 +55,10 @@ function renderNodes(container: HTMLElement, nodes: FolderNode[]): void {
   });
 }
 
+export function renderTree(container: HTMLElement, tree: FolderNode[]): void {
+  renderNodes(container, tree);
+}
+
 export async function refreshFolderTree() {
   folderTree = document.getElementById('folder-tree')!;
   try {

--- a/src/web_app/static/imageBatch.ts
+++ b/src/web_app/static/imageBatch.ts
@@ -2,6 +2,7 @@ import { refreshFiles } from './files.js';
 import { refreshFolderTree } from './folders.js';
 import { openImageEditModal } from './imageEditor.js';
 import { aiExchange, renderDialog } from './uploadForm.js';
+import type { UploadResponse } from './types.js';
 
 export let currentImageIndex = -1;
 export let imageFiles: Array<{ blob: Blob; name: string }> = [];
@@ -64,8 +65,15 @@ export async function uploadEditedImages() {
   });
   const resp = await fetch('/upload/images', { method: 'POST', body: data });
   if (resp.ok) {
-    const result = await resp.json();
-    renderDialog(aiExchange, result.prompt, result.raw_response);
+    const result: UploadResponse = await resp.json();
+    renderDialog(
+      aiExchange,
+      result.prompt,
+      result.raw_response,
+      result.chat_history,
+      result.review_comment,
+      result.created_path
+    );
     imageFiles = [];
     currentImageIndex = -1;
     fileInput.value = '';

--- a/src/web_app/static/js/review.js
+++ b/src/web_app/static/js/review.js
@@ -35,7 +35,14 @@ document.addEventListener('DOMContentLoaded', () => {
         });
       }
       if (dialogEl) {
-        renderDialog(dialogEl, data.prompt, data.raw_response);
+        renderDialog(
+          dialogEl,
+          data.prompt,
+          data.raw_response,
+          data.chat_history,
+          data.review_comment,
+          data.created_path
+        );
       }
     } catch {
       // ignore
@@ -70,7 +77,14 @@ document.addEventListener('DOMContentLoaded', () => {
       if (!resp.ok) return;
       const data = await resp.json();
       if (dialogEl) {
-        renderDialog(dialogEl, data.prompt, data.raw_response);
+        renderDialog(
+          dialogEl,
+          data.prompt,
+          data.raw_response,
+          data.chat_history,
+          data.review_comment,
+          data.created_path
+        );
       }
       if (commentEl) {
         commentEl.value = '';

--- a/src/web_app/static/types.ts
+++ b/src/web_app/static/types.ts
@@ -14,6 +14,7 @@ export interface FileMetadata {
   suggested_name_translit?: string;
   description?: string;
   summary?: string;
+  extracted_text?: string;
 }
 
 export interface FileInfo {
@@ -23,6 +24,12 @@ export interface FileInfo {
   status?: string;
   extracted_text?: string;
   chat_history?: ChatHistory[];
+  missing?: string[];
+  suggested_path?: string;
+  review_comment?: string;
+  prompt?: string;
+  raw_response?: string;
+  created_path?: string;
 }
 
 export interface UploadPendingResponse {
@@ -30,14 +37,23 @@ export interface UploadPendingResponse {
   id: string;
   suggested_path?: string;
   missing?: string[];
+  review_comment?: string;
   prompt?: string;
   raw_response?: string;
+  created_path?: string;
+  chat_history?: ChatHistory[];
 }
 
 export interface UploadFinalResponse {
   status: string;
+  id: string;
+  missing?: string[];
+  suggested_path?: string;
+  review_comment?: string;
   prompt?: string;
   raw_response?: string;
+  created_path?: string;
+  chat_history?: ChatHistory[];
 }
 
 export type UploadResponse = UploadPendingResponse | UploadFinalResponse;

--- a/src/web_app/static/upload.ts
+++ b/src/web_app/static/upload.ts
@@ -6,6 +6,7 @@ import { setupImageBatch } from './imageBatch.js';
 import { setupImageEditor } from './imageEditor.js';
 import { apiRequest } from './http.js';
 import { showNotification } from './notify.js';
+import type { FileInfo } from './types.js';
 
 /**
  * Точка входа инициализации загрузки/редактирования.
@@ -37,7 +38,7 @@ export function setupUpload() {
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ language, psm }),
         });
-        const data = await resp.json();
+        const data: FileInfo = await resp.json();
         textPreview.textContent = data.extracted_text || '';
       } catch {
         showNotification('Ошибка пересканирования');


### PR DESCRIPTION
## Summary
- extend FileInfo and upload responses with review-related fields
- surface review details and chat history in upload and batch flows
- export folder tree helper for tests

## Testing
- `npx tsc`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c07cfe43088330aa48f826d45f2f23