### PR TITLE
feat: add upload wizard

### DIFF
--- a/src/web_app/static/dist/main.js
+++ b/src/web_app/static/dist/main.js
@@ -1,9 +1,13 @@
-import { setupUpload } from './upload.js'; // orchestrates upload modules
+import { setupUploadForm } from './uploadForm.js';
+import { setupImageBatch } from './imageBatch.js';
+import { setupImageEditor } from './imageEditor.js';
 import { setupFiles, refreshFiles } from './files.js';
 import { refreshFolderTree } from './folders.js';
 import { setupChat } from './chat.js';
 document.addEventListener('DOMContentLoaded', () => {
-    setupUpload();
+    setupUploadForm();
+    setupImageEditor();
+    setupImageBatch();
     setupFiles();
     setupChat();
     refreshFiles();

--- a/src/web_app/static/main.ts
+++ b/src/web_app/static/main.ts
@@ -1,10 +1,14 @@
-import { setupUpload } from './upload.js'; // orchestrates upload modules
+import { setupUploadForm } from './uploadForm.js';
+import { setupImageBatch } from './imageBatch.js';
+import { setupImageEditor } from './imageEditor.js';
 import { setupFiles, refreshFiles } from './files.js';
 import { refreshFolderTree } from './folders.js';
 import { setupChat } from './chat.js';
 
 document.addEventListener('DOMContentLoaded', () => {
-  setupUpload();
+  setupUploadForm();
+  setupImageEditor();
+  setupImageBatch();
   setupFiles();
   setupChat();
   refreshFiles();

--- a/src/web_app/static/style.css
+++ b/src/web_app/static/style.css
@@ -160,6 +160,33 @@ button:hover, input[type="submit"]:hover { background-color: var(--color-primary
   justify-content: flex-end;
 }
 
+/* индикатор шагов мастера */
+.step-indicator {
+  display: flex;
+  gap: var(--spacing-sm);
+  margin-bottom: var(--spacing-md);
+}
+.step-indicator .step {
+  flex: 1;
+  text-align: center;
+  padding: var(--spacing-sm);
+  border-bottom: 2px solid var(--color-border);
+}
+.step-indicator .step.active {
+  font-weight: bold;
+  border-color: var(--color-primary);
+}
+.step-indicator .step.completed {
+  color: var(--color-primary);
+  border-color: var(--color-primary);
+}
+
+/* модалки подтверждения */
+.confirm-modal .modal__content {
+  max-width: 300px;
+  text-align: center;
+}
+
 /* from codex/add-camera-capture-to-image-input */
 
 /* from main */


### PR DESCRIPTION
## Summary
- implement multi-step upload wizard with metadata preview and finalization
- style step indicator and confirmation dialogs
- initialize wizard instead of direct upload

## Testing
- `npx tsc -p tsconfig.json`
- `pytest` *(fails: tests/test_web_app.py::test_upload_retrieve_and_download)*

------
https://chatgpt.com/codex/tasks/task_e_68c08ee4ef4083309dee2461f5e15a65