### PR TITLE
feat: clarify metadata via AI

### DIFF
--- a/src/web_app/static/types.ts
+++ b/src/web_app/static/types.ts
@@ -23,6 +23,8 @@ export interface FileInfo {
   status?: string;
   extracted_text?: string;
   chat_history?: ChatHistory[];
+  prompt?: string;
+  raw_response?: string;
 }
 
 export interface UploadPendingResponse {

--- a/src/web_app/templates/index.html
+++ b/src/web_app/templates/index.html
@@ -108,6 +108,7 @@
                     <label><input type="radio" name="name-choice" id="name-original" /> <span id="name-original-label"></span></label>
                     <label><input type="radio" name="name-choice" id="name-latin" /> <span id="name-latin-label"></span></label>
                 </div>
+                <button type="button" id="clarify-btn">Запросить уточнение</button>
                 <button type="submit">Сохранить</button>
             </form>
         </div>


### PR DESCRIPTION
## Summary
- show latest AI exchange after metadata patch
- allow requesting clarification; update form with AI response
- track prompt and raw_response fields

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c07c9966288330bc588eb792fe439a