### PR TITLE
Add draft uploads and finalize endpoint

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -45,7 +45,7 @@ class FileRecord(BaseModel):
     expiration_date: Optional[str] = None
     passport_number: Optional[str] = None
     path: str
-    status: str = "review"
+    status: str = "draft"
     prompt: Any | None = None
     raw_response: Any | None = None
     missing: List[str] = Field(default_factory=list)

--- a/src/web_app/routes/files.py
+++ b/src/web_app/routes/files.py
@@ -127,7 +127,7 @@ async def _scan_output_dir() -> None:
             file_path.name,
             metadata,
             str(file_path),
-            "processed",
+            "finalized",
         )
         existing_records[file_path] = file_id
         existing_paths.add(file_path)
@@ -321,27 +321,22 @@ async def update_file(file_id: str, data: dict = Body(...)):
 
 
 @router.post("/files/{file_id}/finalize", response_model=FileRecord)
-async def finalize_file(file_id: str, data: dict = Body(...)):
-    """Завершить обработку файла и при необходимости создать каталоги."""
+async def finalize_file(file_id: str, data: dict | None = Body(None)):
+    """Переместить файл из черновиков и записать финальные метаданные."""
     record = await run_db(database.get_file, file_id)
     if not record:
         raise HTTPException(status_code=404, detail="File not found")
 
-    if record.status not in {"pending", "review"}:
+    if record.status not in {"draft", "pending"}:
         return record
 
-    missing = data.get("missing") or []
-    confirm = bool(data.get("confirm"))
-
-    if not confirm:
-        await run_db(database.update_file, file_id, missing=missing)
-        return await run_db(database.get_file, file_id)
-
-    temp_path = record.path or str(UPLOAD_DIR / f"{file_id}_{record.filename}")
-
+    metadata_updates = (data or {}).get("metadata") or {}
     meta_dict = record.metadata.model_dump()
-    dest_path, still_missing, confirmed = place_file(
-        str(temp_path),
+    if metadata_updates:
+        meta_dict.update(metadata_updates)
+
+    dest_path, missing, confirmed = place_file(
+        record.path,
         meta_dict,
         server.config.output_dir,
         dry_run=False,
@@ -353,12 +348,10 @@ async def finalize_file(file_id: str, data: dict = Body(...)):
     await run_db(
         database.update_file,
         file_id,
-        metadata,
-        str(dest_path),
-        "processed",
-        record.prompt,
-        record.raw_response,
-        still_missing,
+        metadata=metadata,
+        path=str(dest_path),
+        status="finalized",
+        missing=missing,
         suggested_path=str(dest_path),
         confirmed=confirmed,
         created_path=str(dest_path) if confirmed else None,
@@ -394,7 +387,7 @@ async def rerun_ocr(file_id: str, language: str = Body(...), psm: int = Body(3))
     metadata = record.metadata
     metadata.extracted_text = text
     metadata.language = language
-    await run_db(database.update_file, file_id, metadata=metadata, status="review")
+    await run_db(database.update_file, file_id, metadata=metadata, status="draft")
     return {"extracted_text": text}
 
 

--- a/src/web_app/routes/upload.py
+++ b/src/web_app/routes/upload.py
@@ -131,9 +131,8 @@ async def upload_file(
             dest.write(chunk)
 
     metadata, dest_path, missing, meta_result = await process_uploaded(
-        temp_path, language, dry_run
+        temp_path, language, True
     )
-    final_path = dest_path if not dry_run and not missing else temp_path
     sources = [file.filename]
 
     await run_db(
@@ -141,8 +140,8 @@ async def upload_file(
         file_id,
         file.filename,
         metadata,
-        str(final_path),
-        "review",
+        str(temp_path),
+        "draft",
         meta_result.get("prompt"),
         meta_result.get("raw_response"),
         missing,
@@ -156,8 +155,8 @@ async def upload_file(
         metadata=metadata,
         tags_ru=metadata.tags_ru,
         tags_en=metadata.tags_en,
-        path=str(final_path),
-        status="review",
+        path=str(temp_path),
+        status="draft",
         missing=missing,
         sources=sources,
         prompt=meta_result.get("prompt"),
@@ -207,9 +206,8 @@ async def upload_images(
     shutil.rmtree(temp_dir, ignore_errors=True)
 
     metadata, dest_path, missing, meta_result = await process_uploaded(
-        pdf_path, language, dry_run
+        pdf_path, language, True
     )
-    final_path = dest_path if not dry_run and not missing else pdf_path
     sources = [f.filename for f in sorted_files]
 
     await run_db(
@@ -217,8 +215,8 @@ async def upload_images(
         file_id,
         pdf_path.name,
         metadata,
-        str(final_path),
-        "review",
+        str(pdf_path),
+        "draft",
         meta_result.get("prompt"),
         meta_result.get("raw_response"),
         missing,
@@ -232,8 +230,8 @@ async def upload_images(
         metadata=metadata,
         tags_ru=metadata.tags_ru,
         tags_en=metadata.tags_en,
-        path=str(final_path),
-        status="review",
+        path=str(pdf_path),
+        status="draft",
         missing=missing,
         sources=sources,
         prompt=meta_result.get("prompt"),

--- a/tests/test_finalize_file.py
+++ b/tests/test_finalize_file.py
@@ -67,4 +67,4 @@ def test_finalize_file_moves_and_creates_metadata(tmp_path, monkeypatch):
     assert dest_path.with_suffix(dest_path.suffix + ".json").exists()
 
     assert record is not None
-    assert record.status == "processed"
+    assert record.status == "finalized"

--- a/tests/test_server_import.py
+++ b/tests/test_server_import.py
@@ -19,3 +19,4 @@ def test_server_import_has_no_side_effects(monkeypatch):
     importlib.import_module("web_app.server")
 
     assert not called
+    sys.modules.pop("web_app.server", None)

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -17,6 +17,9 @@ sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
 # Настраиваем окружение ДО импорта сервера
 os.environ["DB_URL"] = ":memory:"             # in-memory БД для тестов
 
+# Обеспечиваем свежий импорт сервера (другие тесты могут его перезагружать)
+sys.modules.pop("web_app.server", None)
+
 # Импортируем сервер
 from web_app import server  # noqa: E402
 from models import Metadata  # noqa: E402
@@ -136,7 +139,7 @@ def test_upload_retrieve_and_download(tmp_path, monkeypatch):
         } <= set(data.keys())
         file_id = data["id"]
         assert data["filename"] == "example.txt"
-        assert data["status"] == "review"
+        assert data["status"] == "draft"
         assert data["missing"] == []
         assert data["metadata"]["extracted_text"].strip() == "content"
         assert data["metadata"]["language"] == "de"


### PR DESCRIPTION
## Summary
- store uploads as drafts and defer moving to archive
- add endpoint to finalize files and commit metadata
- track file status with `draft`/`finalized`

## Testing
- `pytest` *(fails: tests/test_web_app.py::test_upload_retrieve_and_download - AssertionError: assert None == 'John Doe')*


------
https://chatgpt.com/codex/tasks/task_e_68c09121291083308743a7c170f09651