### PR TITLE
feat: добавить поддержку чата в черновиках

### DIFF
--- a/src/web_app/static/chat.ts
+++ b/src/web_app/static/chat.ts
@@ -54,24 +54,33 @@ function renderChat(history: ChatHistory[]) {
   });
 }
 
-export async function openChatModal(file: FileInfo) {
-  currentChatId = file.id;
-  const history = file.chat_history && file.chat_history.length ? file.chat_history : null;
-  if (history) {
-    renderChat(history);
+export async function openChatModal(
+  fileOrId: FileInfo | string,
+  history?: ChatHistory[]
+) {
+  if (typeof fileOrId === 'string') {
+    currentChatId = fileOrId;
+  } else {
+    currentChatId = fileOrId.id;
+    history = fileOrId.chat_history && fileOrId.chat_history.length ? fileOrId.chat_history : history;
+  }
+  const hist = history && history.length ? history : null;
+  if (hist) {
+    renderChat(hist);
     document.dispatchEvent(
-      new CustomEvent('chat-updated', { detail: { id: currentChatId, history } })
+      new CustomEvent('chat-updated', { detail: { id: currentChatId, history: hist } })
     );
     openModal(chatModal);
     return;
   }
+  if (!currentChatId) return;
   try {
-    const resp = await apiRequest(`/files/${file.id}/details`);
+    const resp = await apiRequest(`/files/${currentChatId}/details`);
     const data: FileInfo = await resp.json();
-    const hist = data.chat_history || [];
-    renderChat(hist);
+    const h = data.chat_history || [];
+    renderChat(h);
     document.dispatchEvent(
-      new CustomEvent('chat-updated', { detail: { id: currentChatId, history: hist } })
+      new CustomEvent('chat-updated', { detail: { id: currentChatId, history: h } })
     );
   } catch {
     renderChat([]);

--- a/src/web_app/static/dist/chat.js
+++ b/src/web_app/static/dist/chat.js
@@ -55,22 +55,30 @@ function renderChat(history) {
         chatHistory.appendChild(div);
     });
 }
-export function openChatModal(file) {
+export function openChatModal(fileOrId, history) {
     return __awaiter(this, void 0, void 0, function* () {
-        currentChatId = file.id;
-        const history = file.chat_history && file.chat_history.length ? file.chat_history : null;
-        if (history) {
-            renderChat(history);
-            document.dispatchEvent(new CustomEvent('chat-updated', { detail: { id: currentChatId, history } }));
+        if (typeof fileOrId === 'string') {
+            currentChatId = fileOrId;
+        }
+        else {
+            currentChatId = fileOrId.id;
+            history = fileOrId.chat_history && fileOrId.chat_history.length ? fileOrId.chat_history : history;
+        }
+        const hist = history && history.length ? history : null;
+        if (hist) {
+            renderChat(hist);
+            document.dispatchEvent(new CustomEvent('chat-updated', { detail: { id: currentChatId, history: hist } }));
             openModal(chatModal);
             return;
         }
+        if (!currentChatId)
+            return;
         try {
-            const resp = yield apiRequest(`/files/${file.id}/details`);
+            const resp = yield apiRequest(`/files/${currentChatId}/details`);
             const data = yield resp.json();
-            const hist = data.chat_history || [];
-            renderChat(hist);
-            document.dispatchEvent(new CustomEvent('chat-updated', { detail: { id: currentChatId, history: hist } }));
+            const h = data.chat_history || [];
+            renderChat(h);
+            document.dispatchEvent(new CustomEvent('chat-updated', { detail: { id: currentChatId, history: h } }));
         }
         catch (_a) {
             renderChat([]);

--- a/src/web_app/static/dist/uploadForm.js
+++ b/src/web_app/static/dist/uploadForm.js
@@ -323,14 +323,31 @@ export function setupUploadForm() {
         xhr.send(data);
     });
     askAiBtn.addEventListener('click', () => {
-        if (!currentFile)
+        if (!currentId)
             return;
-        openChatModal(currentFile);
+        openChatModal(currentId, currentFile === null || currentFile === void 0 ? void 0 : currentFile.chat_history);
     });
     document.addEventListener('chat-updated', (ev) => {
         const detail = ev.detail;
         if ((detail === null || detail === void 0 ? void 0 : detail.id) === currentId && currentFile) {
             currentFile.chat_history = detail.history;
+            const last = detail.history[detail.history.length - 1];
+            if ((last === null || last === void 0 ? void 0 : last.role) === 'assistant') {
+                try {
+                    const suggested = JSON.parse(last.message);
+                    inputs.forEach((el) => {
+                        const key = fieldMap[el.id];
+                        if (key && suggested[key]) {
+                            el.value = suggested[key];
+                            currentFile.metadata = currentFile.metadata || {};
+                            currentFile.metadata[key] = suggested[key];
+                        }
+                    });
+                }
+                catch (_a) {
+                    // ответ не содержит JSON с метаданными
+                }
+            }
             renderDialog(previewDialog, undefined, undefined, detail.history, currentFile.review_comment, currentFile.created_path);
         }
     });


### PR DESCRIPTION
## Summary
- поддержка открытия чата по `file_id` и обновления истории
- кнопка «Спросить ИИ» в форме загрузки с учётом текущего файла
- применение предложенных метаданных из ответов ИИ

## Testing
- `npx tsc`
- `pytest -q` *(fails: tests/test_web_app.py::test_upload_retrieve_and_download)*

------
https://chatgpt.com/codex/tasks/task_e_68c095caa5048330b42864372d8708c9