### PR TITLE
feat: add typed file status for uploads

### DIFF
--- a/src/web_app/static/chat.ts
+++ b/src/web_app/static/chat.ts
@@ -1,6 +1,6 @@
 import { apiRequest } from './http.js';
 import { showNotification } from './notify.js';
-import type { ChatHistory, FileInfo } from './types.js';
+import type { ChatHistory, FileInfo, FileStatus } from './types.js';
 
 let chatModal: HTMLElement;
 let chatHistory: HTMLElement;
@@ -62,6 +62,8 @@ export async function openChatModal(
     currentChatId = fileOrId;
   } else {
     currentChatId = fileOrId.id;
+    const fileStatus: FileStatus | undefined = fileOrId.status;
+    void fileStatus;
     history = fileOrId.chat_history && fileOrId.chat_history.length ? fileOrId.chat_history : history;
   }
   const hist = history && history.length ? history : null;

--- a/src/web_app/static/files.ts
+++ b/src/web_app/static/files.ts
@@ -3,7 +3,7 @@ import { apiRequest } from './http.js';
 import { showNotification } from './notify.js';
 import { refreshFolderTree } from './folders.js';
 import { aiExchange, renderDialog } from './uploadForm.js';
-import type { FileInfo, FileMetadata } from './types.js';
+import type { FileInfo, FileMetadata, FileStatus } from './types.js';
 
 let list: HTMLElement;
 let textPreview: HTMLElement;
@@ -230,7 +230,8 @@ export async function refreshFiles(force = false, q = '') {
       tr.appendChild(descTd);
 
       const statusTd = document.createElement('td');
-      statusTd.textContent = f.status;
+      const status: FileStatus | undefined = f.status;
+      statusTd.textContent = status || '';
       tr.appendChild(statusTd);
 
       const actionsTd = document.createElement('td');

--- a/src/web_app/static/types.ts
+++ b/src/web_app/static/types.ts
@@ -3,6 +3,8 @@ export interface ChatHistory {
   message: string;
 }
 
+export type FileStatus = 'draft' | 'pending' | 'finalized' | 'rejected';
+
 export interface FileMetadata {
   category?: string;
   subcategory?: string;
@@ -21,7 +23,7 @@ export interface FileInfo {
   id: string;
   path?: string;
   metadata?: FileMetadata;
-  status?: string;
+  status?: FileStatus;
   extracted_text?: string;
   chat_history?: ChatHistory[];
   missing?: string[];
@@ -33,7 +35,7 @@ export interface FileInfo {
 }
 
 export interface UploadPendingResponse {
-  status: 'pending';
+  status: FileStatus;
   id: string;
   suggested_path?: string;
   missing?: string[];
@@ -45,7 +47,7 @@ export interface UploadPendingResponse {
 }
 
 export interface UploadFinalResponse {
-  status: string;
+  status: FileStatus;
   id: string;
   missing?: string[];
   suggested_path?: string;

--- a/src/web_app/static/uploadForm.ts
+++ b/src/web_app/static/uploadForm.ts
@@ -1,7 +1,7 @@
 import { refreshFiles, openMetadataModal, openModal, closeModal } from './files.js';
 import { refreshFolderTree } from './folders.js';
 import { openChatModal } from './chat.js';
-import type { FileInfo, ChatHistory, UploadResponse } from './types.js';
+import type { FileInfo, ChatHistory, UploadResponse, FileStatus } from './types.js';
 
 export let aiExchange: HTMLElement;
 let metadataModal: HTMLElement;
@@ -302,7 +302,7 @@ export function setupUploadForm() {
               await fetch(`/files/${result.id}`, {
                 method: 'PATCH',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ status: 'rejected' }),
+                body: JSON.stringify({ status: 'rejected' as FileStatus }),
               });
             } catch {
               // ignore errors, просто закрываем модалку

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -217,14 +217,14 @@ def test_upload_retrieve_and_download(tmp_path, monkeypatch):
         finalize = client.post(f"/files/{file_id}/finalize", json={"confirm": True})
         assert finalize.status_code == 200
         final_data = finalize.json()
-        assert final_data["status"] == "processed"
+        assert final_data["status"] == "finalized"
         assert final_data["metadata"]["person"] == "John Doe"
 
         record = server.database.get_file(file_id)
         assert record.person == "John Doe"
         assert record.date_of_birth == "1990-01-02"
         assert record.expiration_date == "2030-01-02"
-        assert record.status == "processed"
+        assert record.status == "finalized"
 
 
 def test_translation_error_returns_502(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- add FileStatus union for document life cycle
- use FileStatus across front-end modules
- adjust web app test for finalized status

## Testing
- `npx tsc -p tsconfig.json`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c0986c83048330bb07d656b7f85a8d