### PR TITLE
feat: add file deletion endpoint

### DIFF
--- a/src/web_app/static/dist/uploadForm.js
+++ b/src/web_app/static/dist/uploadForm.js
@@ -297,17 +297,15 @@ export function setupUploadForm() {
                         }
                     });
                     missingCancel.onclick = () => __awaiter(this, void 0, void 0, function* () {
+                        var _a;
                         try {
-                            yield fetch(`/files/${result.id}`, {
-                                method: 'PATCH',
-                                headers: { 'Content-Type': 'application/json' },
-                                body: JSON.stringify({ status: 'rejected' }),
-                            });
+                            yield fetch(`/files/${result.id}`, { method: 'DELETE' });
                         }
-                        catch (_a) {
+                        catch (_b) {
                             // ignore errors, просто закрываем модалку
                         }
                         missingModal.style.display = 'none';
+                        (_a = document.querySelector(`#files tr[data-id="${result.id}"]`)) === null || _a === void 0 ? void 0 : _a.remove();
                         refreshFiles();
                         updateStep(1);
                     });

--- a/src/web_app/static/uploadForm.ts
+++ b/src/web_app/static/uploadForm.ts
@@ -1,7 +1,7 @@
 import { refreshFiles, openMetadataModal, openModal, closeModal } from './files.js';
 import { refreshFolderTree } from './folders.js';
 import { openChatModal } from './chat.js';
-import type { FileInfo, ChatHistory, UploadResponse, FileStatus } from './types.js';
+import type { FileInfo, ChatHistory, UploadResponse } from './types.js';
 
 export let aiExchange: HTMLElement;
 let metadataModal: HTMLElement;
@@ -299,15 +299,12 @@ export function setupUploadForm() {
           };
           missingCancel.onclick = async () => {
             try {
-              await fetch(`/files/${result.id}`, {
-                method: 'PATCH',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ status: 'rejected' as FileStatus }),
-              });
+              await fetch(`/files/${result.id}`, { method: 'DELETE' });
             } catch {
               // ignore errors, просто закрываем модалку
             }
             missingModal.style.display = 'none';
+            document.querySelector(`#files tr[data-id="${result.id}"]`)?.remove();
             refreshFiles();
             updateStep(1);
           };

--- a/tests/test_finalize_file.py
+++ b/tests/test_finalize_file.py
@@ -108,3 +108,41 @@ def test_comment_persists_after_finalize(tmp_path, monkeypatch):
         data = file_resp.json()
         assert data["chat_history"][-1]["message"] == comment_msg
         assert data["review_comment"] == comment_msg
+
+
+def test_delete_file(tmp_path, monkeypatch):
+    asyncio.run(server.database.run_db(server.database.init_db))
+    server.config.output_dir = str(tmp_path / "archive")
+    upload_dir = tmp_path / "uploads"
+    upload_dir.mkdir()
+    monkeypatch.setattr(upload, "UPLOAD_DIR", upload_dir)
+    monkeypatch.setattr(upload, "OCR_AVAILABLE", True)
+
+    monkeypatch.setattr(server, "extract_text", lambda path, language="eng": "")
+    monkeypatch.setattr(
+        server.metadata_generation, "generate_metadata", _mock_generate_metadata
+    )
+
+    with TestClient(app) as client:
+        resp = client.post("/upload", files={"file": ("test.pdf", b"data")})
+        assert resp.status_code == 200
+        upload_data = resp.json()
+        file_id = upload_data["id"]
+
+        finalize_resp = client.post(
+            f"/files/{file_id}/finalize", json={"confirm": True}
+        )
+        assert finalize_resp.status_code == 200
+        dest_path = Path(finalize_resp.json()["path"])
+        meta_path = dest_path.with_suffix(dest_path.suffix + ".json")
+        assert dest_path.exists() and meta_path.exists()
+
+        del_resp = client.delete(f"/files/{file_id}")
+        assert del_resp.status_code == 200
+        file_resp = client.get(f"/files/{file_id}")
+        assert file_resp.status_code == 404
+        db_record = server.database.get_file(file_id)
+
+    assert db_record is None
+    assert not dest_path.exists()
+    assert not meta_path.exists()


### PR DESCRIPTION
## Summary
- add DELETE /files/{id} endpoint to remove file, JSON, and DB entry
- call DELETE on cancel in upload form and remove item from list
- cover deletion with test

## Testing
- `npx tsc`
- `pytest tests/test_finalize_file.py`


------
https://chatgpt.com/codex/tasks/task_e_68c09d20f7ac83309c9b56f08bdd6554