### PR TITLE
feat(frontend): support extended metadata fields

### DIFF
--- a/src/web_app/static/dist/files.js
+++ b/src/web_app/static/dist/files.js
@@ -25,6 +25,11 @@ let editCategory;
 let editSubcategory;
 let editIssuer;
 let editDate;
+let editPerson;
+let editDocType;
+let editLanguage;
+let editNeedsFolder;
+let editNewNameTranslit;
 let editName;
 let editDescription;
 let editSummary;
@@ -57,6 +62,11 @@ export function setupFiles() {
     editSubcategory = document.getElementById('edit-subcategory');
     editIssuer = document.getElementById('edit-issuer');
     editDate = document.getElementById('edit-date');
+    editPerson = document.getElementById('edit-person');
+    editDocType = document.getElementById('edit-doc-type');
+    editLanguage = document.getElementById('edit-language');
+    editNeedsFolder = document.getElementById('edit-needs-new-folder');
+    editNewNameTranslit = document.getElementById('edit-new-name-translit');
     editName = document.getElementById('edit-name');
     editDescription = document.getElementById('edit-description');
     editSummary = document.getElementById('edit-summary');
@@ -80,6 +90,11 @@ export function setupFiles() {
                 subcategory: editSubcategory.value.trim(),
                 issuer: editIssuer.value.trim(),
                 date: editDate.value,
+                person: editPerson === null || editPerson === void 0 ? void 0 : editPerson.value.trim(),
+                doc_type: editDocType === null || editDocType === void 0 ? void 0 : editDocType.value.trim(),
+                language: editLanguage === null || editLanguage === void 0 ? void 0 : editLanguage.value.trim(),
+                new_name_translit: editNewNameTranslit === null || editNewNameTranslit === void 0 ? void 0 : editNewNameTranslit.value.trim(),
+                needs_new_folder: (editNeedsFolder === null || editNeedsFolder === void 0 ? void 0 : editNeedsFolder.checked) ? true : undefined,
                 suggested_name: editName.value.trim(),
                 description: editDescription.value.trim(),
             },
@@ -230,7 +245,8 @@ export function refreshFiles() {
                 descTd.classList.add('description');
                 tr.appendChild(descTd);
                 const statusTd = document.createElement('td');
-                statusTd.textContent = f.status;
+                const status = f.status;
+                statusTd.textContent = status || '';
                 tr.appendChild(statusTd);
                 const actionsTd = document.createElement('td');
                 const langParam = displayLang ? `?lang=${encodeURIComponent(displayLang)}` : '';
@@ -300,6 +316,11 @@ function populateMetadataForm(file) {
     editCategory.value = m.category || '';
     editSubcategory.value = m.subcategory || '';
     editIssuer.value = m.issuer || '';
+    editPerson && (editPerson.value = m.person || '');
+    editDocType && (editDocType.value = m.doc_type || '');
+    editLanguage && (editLanguage.value = m.language || '');
+    editNeedsFolder && (editNeedsFolder.checked = m.needs_new_folder || false);
+    editNewNameTranslit && (editNewNameTranslit.value = m.new_name_translit || '');
     editDate.value = m.date || '';
     const orig = m.suggested_name || '';
     const latin = m.suggested_name_translit || orig;

--- a/src/web_app/static/dist/uploadForm.js
+++ b/src/web_app/static/dist/uploadForm.js
@@ -36,6 +36,11 @@ const fieldMap = {
     'edit-name': 'suggested_name',
     'edit-description': 'description',
     'edit-summary': 'summary',
+    'edit-person': 'person',
+    'edit-doc-type': 'doc_type',
+    'edit-language': 'language',
+    'edit-new-name-translit': 'new_name_translit',
+    'edit-needs-new-folder': 'needs_new_folder',
 };
 function updateStep(step) {
     currentStep = step;
@@ -220,6 +225,11 @@ export function setupUploadForm() {
             const key = fieldMap[el.id];
             if (!key || key === 'summary')
                 return;
+            if (el instanceof HTMLInputElement && el.type === 'checkbox') {
+                if (el.checked)
+                    meta[key] = true;
+                return;
+            }
             const v = el.value.trim();
             if (v)
                 meta[key] = v;
@@ -335,8 +345,13 @@ export function setupUploadForm() {
                     const suggested = JSON.parse(last.message);
                     inputs.forEach((el) => {
                         const key = fieldMap[el.id];
-                        if (key && suggested[key]) {
-                            el.value = suggested[key];
+                        if (key && suggested[key] !== undefined) {
+                            if (el instanceof HTMLInputElement && el.type === 'checkbox') {
+                                el.checked = Boolean(suggested[key]);
+                            }
+                            else {
+                                el.value = suggested[key];
+                            }
                             currentFile.metadata = currentFile.metadata || {};
                             currentFile.metadata[key] = suggested[key];
                         }

--- a/src/web_app/static/files.ts
+++ b/src/web_app/static/files.ts
@@ -18,6 +18,11 @@ let editCategory: HTMLInputElement;
 let editSubcategory: HTMLInputElement;
 let editIssuer: HTMLInputElement;
 let editDate: HTMLInputElement;
+let editPerson: HTMLInputElement | null;
+let editDocType: HTMLInputElement | null;
+let editLanguage: HTMLInputElement | null;
+let editNeedsFolder: HTMLInputElement | null;
+let editNewNameTranslit: HTMLInputElement | null;
 let editName: HTMLInputElement;
 let editDescription: HTMLTextAreaElement;
 let editSummary: HTMLTextAreaElement;
@@ -50,6 +55,11 @@ export function setupFiles() {
   editSubcategory = document.getElementById('edit-subcategory') as HTMLInputElement;
   editIssuer = document.getElementById('edit-issuer') as HTMLInputElement;
   editDate = document.getElementById('edit-date') as HTMLInputElement;
+  editPerson = document.getElementById('edit-person') as HTMLInputElement | null;
+  editDocType = document.getElementById('edit-doc-type') as HTMLInputElement | null;
+  editLanguage = document.getElementById('edit-language') as HTMLInputElement | null;
+  editNeedsFolder = document.getElementById('edit-needs-new-folder') as HTMLInputElement | null;
+  editNewNameTranslit = document.getElementById('edit-new-name-translit') as HTMLInputElement | null;
   editName = document.getElementById('edit-name') as HTMLInputElement;
   editDescription = document.getElementById('edit-description') as HTMLTextAreaElement;
   editSummary = document.getElementById('edit-summary') as HTMLTextAreaElement;
@@ -75,6 +85,11 @@ export function setupFiles() {
         subcategory: editSubcategory.value.trim(),
         issuer: editIssuer.value.trim(),
         date: editDate.value,
+        person: editPerson?.value.trim(),
+        doc_type: editDocType?.value.trim(),
+        language: editLanguage?.value.trim(),
+        new_name_translit: editNewNameTranslit?.value.trim(),
+        needs_new_folder: editNeedsFolder?.checked ? true : undefined,
         suggested_name: editName.value.trim(),
         description: editDescription.value.trim(),
       },
@@ -307,6 +322,11 @@ function populateMetadataForm(file: FileInfo) {
   editCategory.value = m.category || '';
   editSubcategory.value = m.subcategory || '';
   editIssuer.value = m.issuer || '';
+  editPerson && (editPerson.value = m.person || '');
+  editDocType && (editDocType.value = m.doc_type || '');
+  editLanguage && (editLanguage.value = m.language || '');
+  editNeedsFolder && (editNeedsFolder.checked = m.needs_new_folder || false);
+  editNewNameTranslit && (editNewNameTranslit.value = m.new_name_translit || '');
   editDate.value = m.date || '';
   const orig = m.suggested_name || '';
   const latin = m.suggested_name_translit || orig;

--- a/src/web_app/static/types.ts
+++ b/src/web_app/static/types.ts
@@ -9,14 +9,29 @@ export interface FileMetadata {
   category?: string;
   subcategory?: string;
   issuer?: string;
+  person?: string;
+  doc_type?: string;
   date?: string;
+  date_of_birth?: string;
+  expiration_date?: string;
+  passport_number?: string;
+  amount?: string;
+  counterparty?: string;
+  document_number?: string;
+  due_date?: string;
+  currency?: string;
+  tags?: string[];
   tags_ru?: string[];
   tags_en?: string[];
+  suggested_filename?: string;
   suggested_name?: string;
   suggested_name_translit?: string;
-  description?: string;
   summary?: string;
+  description?: string;
+  needs_new_folder?: boolean;
   extracted_text?: string;
+  language?: string;
+  new_name_translit?: string;
 }
 
 export interface FileInfo {

--- a/src/web_app/static/uploadForm.ts
+++ b/src/web_app/static/uploadForm.ts
@@ -29,6 +29,11 @@ const fieldMap: Record<string, string> = {
   'edit-name': 'suggested_name',
   'edit-description': 'description',
   'edit-summary': 'summary',
+  'edit-person': 'person',
+  'edit-doc-type': 'doc_type',
+  'edit-language': 'language',
+  'edit-new-name-translit': 'new_name_translit',
+  'edit-needs-new-folder': 'needs_new_folder',
 };
 
 function updateStep(step: number) {
@@ -215,10 +220,14 @@ export function setupUploadForm() {
 
   finalizeConfirm.addEventListener('click', async () => {
     if (!currentId) return;
-    const meta: Record<string, string> = {};
+    const meta: Record<string, string | boolean> = {};
     inputs.forEach((el) => {
       const key = fieldMap[el.id];
       if (!key || key === 'summary') return;
+      if (el instanceof HTMLInputElement && el.type === 'checkbox') {
+        if (el.checked) meta[key] = true;
+        return;
+      }
       const v = el.value.trim();
       if (v) meta[key] = v;
     });
@@ -332,8 +341,12 @@ export function setupUploadForm() {
           const suggested = JSON.parse(last.message);
           inputs.forEach((el) => {
             const key = fieldMap[el.id];
-            if (key && suggested[key]) {
-              el.value = suggested[key];
+            if (key && suggested[key] !== undefined) {
+              if (el instanceof HTMLInputElement && el.type === 'checkbox') {
+                el.checked = Boolean(suggested[key]);
+              } else {
+                el.value = suggested[key];
+              }
               currentFile!.metadata = currentFile!.metadata || {};
               (currentFile!.metadata as any)[key] = suggested[key];
             }


### PR DESCRIPTION
## Summary
- expand FileMetadata with person, doc_type, language and other fields
- wire new metadata fields into edit and upload forms
- compile TypeScript frontend

## Testing
- `npx tsc`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c09f4d5a3483308c3b25da2c358662