### PR TITLE
feat(frontend): support missing file status

### DIFF
--- a/src/web_app/static/dist/uploadForm.js
+++ b/src/web_app/static/dist/uploadForm.js
@@ -268,7 +268,7 @@ export function setupUploadForm() {
         xhr.onload = () => {
             if (xhr.status === 200) {
                 const result = JSON.parse(xhr.responseText);
-                if (result.status === 'pending') {
+                if (result.status === 'pending' || result.status === 'missing') {
                     suggestedPath.textContent = result.suggested_path || '';
                     missingList.innerHTML = '';
                     (result.missing || []).forEach((path) => {

--- a/src/web_app/static/types.ts
+++ b/src/web_app/static/types.ts
@@ -3,7 +3,7 @@ export interface ChatHistory {
   message: string;
 }
 
-export type FileStatus = 'draft' | 'pending' | 'finalized' | 'rejected';
+export type FileStatus = 'draft' | 'pending' | 'finalized' | 'rejected' | 'missing';
 
 export interface FileMetadata {
   category?: string;

--- a/src/web_app/static/uploadForm.ts
+++ b/src/web_app/static/uploadForm.ts
@@ -264,7 +264,7 @@ export function setupUploadForm() {
     xhr.onload = () => {
       if (xhr.status === 200) {
         const result: UploadResponse = JSON.parse(xhr.responseText);
-        if (result.status === 'pending') {
+        if (result.status === 'pending' || result.status === 'missing') {
           suggestedPath.textContent = result.suggested_path || '';
           missingList.innerHTML = '';
           (result.missing || []).forEach((path: string) => {


### PR DESCRIPTION
## Summary
- extend `FileStatus` with `missing`
- handle `missing` status in upload form
- rebuild frontend assets

## Testing
- `make build-frontend`
- `pytest`
- `npm run lint` *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68c09f4b45788330b3d7ca98af1f2b4c