### PR TITLE
feat: require confirmation to finalize files

### DIFF
--- a/tests/test_finalize_file.py
+++ b/tests/test_finalize_file.py
@@ -116,7 +116,15 @@ def test_finalize_pending_file_creates_dirs(tmp_path):
         assert data["status"] == "pending"
         assert data["missing"] == missing
 
-        finalize_resp = client.post(f"/files/{file_id}/finalize")
+        preview_resp = client.post(
+            f"/files/{file_id}/finalize", json={"confirm": False}
+        )
+        assert preview_resp.status_code == 200
+        assert preview_resp.json()["missing"] == missing
+
+        finalize_resp = client.post(
+            f"/files/{file_id}/finalize", json={"confirm": True}
+        )
         assert finalize_resp.status_code == 200
         final_data = finalize_resp.json()
         new_path = Path(final_data["path"])


### PR DESCRIPTION
## Summary
- add `confirm` flag to finalize endpoint to preview missing folders without moving files
- only move files and update database when confirmation provided
- adjust tests for new confirmation workflow

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c1449b80d883309004d7f120a4405d