### PR TITLE
Запрет чата для финализированных и отклонённых файлов

### DIFF
--- a/src/web_app/static/chat.ts
+++ b/src/web_app/static/chat.ts
@@ -63,7 +63,10 @@ export async function openChatModal(
   } else {
     currentChatId = fileOrId.id;
     const fileStatus: FileStatus | undefined = fileOrId.status;
-    void fileStatus;
+    if (fileStatus === 'finalized' || fileStatus === 'rejected') {
+      showNotification('Чат недоступен для финализированных или отклонённых файлов');
+      return;
+    }
     history = fileOrId.chat_history && fileOrId.chat_history.length ? fileOrId.chat_history : history;
   }
   const hist = history && history.length ? history : null;
@@ -79,6 +82,10 @@ export async function openChatModal(
   try {
     const resp = await apiRequest(`/files/${currentChatId}/details`);
     const data: FileInfo = await resp.json();
+    if (data.status === 'finalized' || data.status === 'rejected') {
+      showNotification('Чат недоступен для финализированных или отклонённых файлов');
+      return;
+    }
     const h = data.chat_history || [];
     renderChat(h);
     document.dispatchEvent(

--- a/src/web_app/static/dist/chat.js
+++ b/src/web_app/static/dist/chat.js
@@ -62,6 +62,11 @@ export function openChatModal(fileOrId, history) {
         }
         else {
             currentChatId = fileOrId.id;
+            const fileStatus = fileOrId.status;
+            if (fileStatus === 'finalized' || fileStatus === 'rejected') {
+                showNotification('Чат недоступен для финализированных или отклонённых файлов');
+                return;
+            }
             history = fileOrId.chat_history && fileOrId.chat_history.length ? fileOrId.chat_history : history;
         }
         const hist = history && history.length ? history : null;
@@ -76,6 +81,10 @@ export function openChatModal(fileOrId, history) {
         try {
             const resp = yield apiRequest(`/files/${currentChatId}/details`);
             const data = yield resp.json();
+            if (data.status === 'finalized' || data.status === 'rejected') {
+                showNotification('Чат недоступен для финализированных или отклонённых файлов');
+                return;
+            }
             const h = data.chat_history || [];
             renderChat(h);
             document.dispatchEvent(new CustomEvent('chat-updated', { detail: { id: currentChatId, history: h } }));


### PR DESCRIPTION
## Summary
- Блокировка открытия чата для файлов в статусе `finalized` или `rejected`
- Обновлён скомпилированный JavaScript

## Testing
- `npx tsc`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c144a3a9d88330a0f680e73cc9de12