### PR TITLE
feat: add metadata fields to index page

### DIFF
--- a/src/web_app/templates/index.html
+++ b/src/web_app/templates/index.html
@@ -100,10 +100,15 @@
                 <label>Категория: <input type="text" id="edit-category" /></label>
                 <label>Подкатегория: <input type="text" id="edit-subcategory" /></label>
                 <label>Организация: <input type="text" id="edit-issuer" /></label>
+                <label>Человек: <input type="text" id="edit-person" /></label>
+                <label>Тип документа: <input type="text" id="edit-doc-type" /></label>
+                <label>Язык: <input type="text" id="edit-language" /></label>
                 <label>Дата: <input type="date" id="edit-date" /></label>
                 <label>Имя: <input type="text" id="edit-name" /></label>
+                <label>Имя (транслит): <input type="text" id="edit-new-name-translit" /></label>
                 <label>Сводка: <textarea id="edit-summary" readonly></textarea></label>
                 <label>Описание: <textarea id="edit-description"></textarea></label>
+                <label><input type="checkbox" id="edit-needs-new-folder" /> Нужна новая папка</label>
                 <div id="name-options">
                     <label><input type="radio" name="name-choice" id="name-original" /> <span id="name-original-label"></span></label>
                     <label><input type="radio" name="name-choice" id="name-latin" /> <span id="name-latin-label"></span></label>


### PR DESCRIPTION
## Summary
- add person, doc_type, language, new_name_translit, and needs_new_folder fields to metadata modal

## Testing
- `npx tsc`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c18f7dd95c8330bb34b95b271cfe80