### PR TITLE
Add translation fields and confirmation status in frontend

### DIFF
--- a/src/web_app/static/chat.ts
+++ b/src/web_app/static/chat.ts
@@ -45,19 +45,40 @@ export function setupChat() {
   });
 }
 
-function renderChat(history: ChatHistory[]) {
+function renderChat(
+  history: ChatHistory[],
+  translatedText?: string,
+  translationLang?: string,
+  confirmed?: boolean
+) {
   chatHistory.innerHTML = '';
   history.forEach((msg: ChatHistory) => {
     const div = document.createElement('div');
     div.textContent = `${msg.role}: ${msg.message}`;
     chatHistory.appendChild(div);
   });
+  if (translatedText) {
+    const transDiv = document.createElement('div');
+    transDiv.className = 'chat-translation';
+    const langLabel = translationLang ? ` (${translationLang})` : '';
+    transDiv.textContent = `Перевод${langLabel}: ${translatedText}`;
+    chatHistory.appendChild(transDiv);
+  }
+  if (typeof confirmed === 'boolean') {
+    const confDiv = document.createElement('div');
+    confDiv.className = 'chat-confirmed';
+    confDiv.textContent = confirmed ? 'Путь подтверждён' : 'Путь не подтверждён';
+    chatHistory.appendChild(confDiv);
+  }
 }
 
 export async function openChatModal(
   fileOrId: FileInfo | string,
   history?: ChatHistory[]
 ) {
+  let translatedText: string | undefined;
+  let translationLang: string | undefined;
+  let confirmed: boolean | undefined;
   if (typeof fileOrId === 'string') {
     currentChatId = fileOrId;
   } else {
@@ -68,10 +89,13 @@ export async function openChatModal(
       return;
     }
     history = fileOrId.chat_history && fileOrId.chat_history.length ? fileOrId.chat_history : history;
+    translatedText = fileOrId.translated_text;
+    translationLang = fileOrId.translation_lang;
+    confirmed = fileOrId.confirmed;
   }
   const hist = history && history.length ? history : null;
   if (hist) {
-    renderChat(hist);
+    renderChat(hist, translatedText, translationLang, confirmed);
     document.dispatchEvent(
       new CustomEvent('chat-updated', { detail: { id: currentChatId, history: hist } })
     );
@@ -87,7 +111,7 @@ export async function openChatModal(
       return;
     }
     const h = data.chat_history || [];
-    renderChat(h);
+    renderChat(h, data.translated_text, data.translation_lang, data.confirmed);
     document.dispatchEvent(
       new CustomEvent('chat-updated', { detail: { id: currentChatId, history: h } })
     );

--- a/src/web_app/static/files.ts
+++ b/src/web_app/static/files.ts
@@ -106,7 +106,15 @@ export function setupFiles() {
       });
       if (!resp.ok) throw new Error();
       const data: FileInfo = await resp.json();
-      renderDialog(aiExchange, data.prompt, data.raw_response);
+      renderDialog(
+        aiExchange,
+        data.prompt,
+        data.raw_response,
+        undefined,
+        undefined,
+        undefined,
+        data.confirmed
+      );
       closeModal(metadataModal);
       currentEditId = null;
       await refreshFiles();
@@ -127,7 +135,15 @@ export function setupFiles() {
       if (!resp.ok) throw new Error();
       const data: FileInfo = await resp.json();
       populateMetadataForm(data);
-      renderDialog(aiExchange, data.prompt, data.raw_response);
+      renderDialog(
+        aiExchange,
+        data.prompt,
+        data.raw_response,
+        undefined,
+        undefined,
+        undefined,
+        data.confirmed
+      );
     } catch {
       showNotification('Ошибка запроса');
     }
@@ -154,7 +170,11 @@ export function setupFiles() {
       const resp = await apiRequest(`/files/${id}/details`);
       if (!resp.ok) throw new Error();
       const data: FileInfo = await resp.json();
-      textPreview.textContent = data.extracted_text || '';
+      const text =
+        displayLang && data.translation_lang === displayLang && data.translated_text
+          ? data.translated_text
+          : data.extracted_text || '';
+      textPreview.textContent = text;
       (textPreview as HTMLElement).dataset.id = id;
     } catch {
       textPreview.textContent = '';
@@ -246,7 +266,11 @@ export async function refreshFiles(force = false, q = '') {
 
       const statusTd = document.createElement('td');
       const status: FileStatus | undefined = f.status;
-      statusTd.textContent = status || '';
+      let statusText = status || '';
+      if (typeof f.confirmed === 'boolean') {
+        statusText += f.confirmed ? ' (подтв.)' : ' (не подтв.)';
+      }
+      statusTd.textContent = statusText;
       tr.appendChild(statusTd);
 
       const actionsTd = document.createElement('td');

--- a/src/web_app/static/types.ts
+++ b/src/web_app/static/types.ts
@@ -44,6 +44,9 @@ export interface FileInfo {
   sources?: string[];
   status?: FileStatus;
   extracted_text?: string;
+  translated_text?: string;
+  translation_lang?: string;
+  confirmed?: boolean;
   chat_history?: ChatHistory[];
   missing?: string[];
   suggested_path?: string;

--- a/src/web_app/static/uploadForm.ts
+++ b/src/web_app/static/uploadForm.ts
@@ -54,7 +54,8 @@ export function renderDialog(
   response?: string,
   history?: ChatHistory[],
   reviewComment?: string,
-  createdPath?: string
+  createdPath?: string,
+  confirmed?: boolean
 ) {
   container.innerHTML = '';
   if (history && history.length) {
@@ -75,6 +76,12 @@ export function renderDialog(
       pathDiv.className = 'ai-message system';
       pathDiv.textContent = createdPath;
       container.appendChild(pathDiv);
+    }
+    if (typeof confirmed === 'boolean') {
+      const confDiv = document.createElement('div');
+      confDiv.className = 'ai-message system';
+      confDiv.textContent = confirmed ? 'Путь подтверждён' : 'Путь не подтверждён';
+      container.appendChild(confDiv);
     }
     return;
   }
@@ -101,6 +108,12 @@ export function renderDialog(
     pathDiv.className = 'ai-message system';
     pathDiv.textContent = createdPath;
     container.appendChild(pathDiv);
+  }
+  if (typeof confirmed === 'boolean') {
+    const confDiv = document.createElement('div');
+    confDiv.className = 'ai-message system';
+    confDiv.textContent = confirmed ? 'Путь подтверждён' : 'Путь не подтверждён';
+    container.appendChild(confDiv);
   }
 }
 
@@ -317,7 +330,8 @@ export function setupUploadForm() {
             result.raw_response,
             result.chat_history,
             result.review_comment,
-            result.created_path
+            result.created_path,
+            result.confirmed
           );
           missingModal.style.display = 'flex';
           updateStep(2);
@@ -391,7 +405,8 @@ export function setupUploadForm() {
         undefined,
         detail.history,
         currentFile.review_comment,
-        currentFile.created_path
+        currentFile.created_path,
+        currentFile.confirmed
       );
     }
   });
@@ -419,9 +434,10 @@ function openPreviewModal(result: FileInfo) {
     result.raw_response,
     result.chat_history,
     result.review_comment,
-    result.created_path
+    result.created_path,
+    result.confirmed
   );
-  textPreview.value = result.metadata?.extracted_text || '';
+  textPreview.value = result.translated_text || result.metadata?.extracted_text || '';
   const saveBtn = editForm.querySelector('button[type="submit"]') as HTMLButtonElement;
   saveBtn.style.display = 'none';
   inputs.forEach((el) => (el.disabled = true));


### PR DESCRIPTION
## Summary
- support `translated_text`, `translation_lang`, and `confirmed` in `FileInfo`
- show translation and confirmation in upload preview, files list, and chat

## Testing
- `npx tsc` *(fails: command not found)*
- `pytest` *(fails: FileNotFoundError: 'node')*


------
https://chatgpt.com/codex/tasks/task_e_68c191203fdc8330afca11092a94e3c9