### PR TITLE
refactor: add explicit chat roles

### DIFF
--- a/src/web_app/static/chat.ts
+++ b/src/web_app/static/chat.ts
@@ -52,9 +52,15 @@ function renderChat(
   confirmed?: boolean
 ) {
   chatHistory.innerHTML = '';
+  const roleLabels: Record<ChatHistory['role'], string> = {
+    user: 'user',
+    assistant: 'assistant',
+    reviewer: 'reviewer',
+    system: 'system',
+  };
   history.forEach((msg: ChatHistory) => {
     const div = document.createElement('div');
-    div.textContent = `${msg.role}: ${msg.message}`;
+    div.textContent = `${roleLabels[msg.role]}: ${msg.message}`;
     chatHistory.appendChild(div);
   });
   if (translatedText) {

--- a/src/web_app/static/dist/chat.js
+++ b/src/web_app/static/dist/chat.js
@@ -47,16 +47,38 @@ export function setupChat() {
         }
     }));
 }
-function renderChat(history) {
+function renderChat(history, translatedText, translationLang, confirmed) {
     chatHistory.innerHTML = '';
+    const roleLabels = {
+        user: 'user',
+        assistant: 'assistant',
+        reviewer: 'reviewer',
+        system: 'system',
+    };
     history.forEach((msg) => {
         const div = document.createElement('div');
-        div.textContent = `${msg.role}: ${msg.message}`;
+        div.textContent = `${roleLabels[msg.role]}: ${msg.message}`;
         chatHistory.appendChild(div);
     });
+    if (translatedText) {
+        const transDiv = document.createElement('div');
+        transDiv.className = 'chat-translation';
+        const langLabel = translationLang ? ` (${translationLang})` : '';
+        transDiv.textContent = `Перевод${langLabel}: ${translatedText}`;
+        chatHistory.appendChild(transDiv);
+    }
+    if (typeof confirmed === 'boolean') {
+        const confDiv = document.createElement('div');
+        confDiv.className = 'chat-confirmed';
+        confDiv.textContent = confirmed ? 'Путь подтверждён' : 'Путь не подтверждён';
+        chatHistory.appendChild(confDiv);
+    }
 }
 export function openChatModal(fileOrId, history) {
     return __awaiter(this, void 0, void 0, function* () {
+        let translatedText;
+        let translationLang;
+        let confirmed;
         if (typeof fileOrId === 'string') {
             currentChatId = fileOrId;
         }
@@ -68,10 +90,13 @@ export function openChatModal(fileOrId, history) {
                 return;
             }
             history = fileOrId.chat_history && fileOrId.chat_history.length ? fileOrId.chat_history : history;
+            translatedText = fileOrId.translated_text;
+            translationLang = fileOrId.translation_lang;
+            confirmed = fileOrId.confirmed;
         }
         const hist = history && history.length ? history : null;
         if (hist) {
-            renderChat(hist);
+            renderChat(hist, translatedText, translationLang, confirmed);
             document.dispatchEvent(new CustomEvent('chat-updated', { detail: { id: currentChatId, history: hist } }));
             openModal(chatModal);
             return;
@@ -86,7 +111,7 @@ export function openChatModal(fileOrId, history) {
                 return;
             }
             const h = data.chat_history || [];
-            renderChat(h);
+            renderChat(h, data.translated_text, data.translation_lang, data.confirmed);
             document.dispatchEvent(new CustomEvent('chat-updated', { detail: { id: currentChatId, history: h } }));
         }
         catch (_a) {

--- a/src/web_app/static/dist/uploadForm.js
+++ b/src/web_app/static/dist/uploadForm.js
@@ -54,12 +54,18 @@ function updateStep(step) {
         el.classList.toggle('completed', s < step);
     });
 }
-export function renderDialog(container, prompt, response, history, reviewComment, createdPath) {
+export function renderDialog(container, prompt, response, history, reviewComment, createdPath, confirmed) {
     container.innerHTML = '';
     if (history && history.length) {
+        const roleClassMap = {
+            user: 'user',
+            assistant: 'assistant',
+            reviewer: 'reviewer',
+            system: 'system',
+        };
         history.forEach((msg) => {
             const div = document.createElement('div');
-            div.className = `ai-message ${msg.role === 'user' ? 'user' : 'assistant'}`;
+            div.className = `ai-message ${roleClassMap[msg.role]}`;
             div.textContent = msg.message;
             container.appendChild(div);
         });
@@ -74,6 +80,12 @@ export function renderDialog(container, prompt, response, history, reviewComment
             pathDiv.className = 'ai-message system';
             pathDiv.textContent = createdPath;
             container.appendChild(pathDiv);
+        }
+        if (typeof confirmed === 'boolean') {
+            const confDiv = document.createElement('div');
+            confDiv.className = 'ai-message system';
+            confDiv.textContent = confirmed ? 'Путь подтверждён' : 'Путь не подтверждён';
+            container.appendChild(confDiv);
         }
         return;
     }
@@ -100,6 +112,12 @@ export function renderDialog(container, prompt, response, history, reviewComment
         pathDiv.className = 'ai-message system';
         pathDiv.textContent = createdPath;
         container.appendChild(pathDiv);
+    }
+    if (typeof confirmed === 'boolean') {
+        const confDiv = document.createElement('div');
+        confDiv.className = 'ai-message system';
+        confDiv.textContent = confirmed ? 'Путь подтверждён' : 'Путь не подтверждён';
+        container.appendChild(confDiv);
     }
 }
 export function setupUploadForm() {
@@ -318,7 +336,7 @@ export function setupUploadForm() {
                         li.textContent = path;
                         missingList.appendChild(li);
                     });
-                    renderDialog(missingDialog, result.prompt, result.raw_response, result.chat_history, result.review_comment, result.created_path);
+                    renderDialog(missingDialog, result.prompt, result.raw_response, result.chat_history, result.review_comment, result.created_path, result.confirmed);
                     missingModal.style.display = 'flex';
                     updateStep(2);
                     missingConfirm.onclick = () => __awaiter(this, void 0, void 0, function* () {
@@ -393,7 +411,7 @@ export function setupUploadForm() {
                     // ответ не содержит JSON с метаданными
                 }
             }
-            renderDialog(previewDialog, undefined, undefined, detail.history, currentFile.review_comment, currentFile.created_path);
+            renderDialog(previewDialog, undefined, undefined, detail.history, currentFile.review_comment, currentFile.created_path, currentFile.confirmed);
         }
     });
     document.addEventListener('keydown', (e) => {
@@ -413,8 +431,8 @@ function openPreviewModal(result) {
     rerunOcrBtn.style.display = 'inline-block';
     buttonsWrap.style.display = 'flex';
     updateStep(2);
-    renderDialog(previewDialog, result.prompt, result.raw_response, result.chat_history, result.review_comment, result.created_path);
-    textPreview.value = ((_a = result.metadata) === null || _a === void 0 ? void 0 : _a.extracted_text) || '';
+    renderDialog(previewDialog, result.prompt, result.raw_response, result.chat_history, result.review_comment, result.created_path, result.confirmed);
+    textPreview.value = result.translated_text || ((_a = result.metadata) === null || _a === void 0 ? void 0 : _a.extracted_text) || '';
     const saveBtn = editForm.querySelector('button[type="submit"]');
     saveBtn.style.display = 'none';
     inputs.forEach((el) => (el.disabled = true));

--- a/src/web_app/static/types.ts
+++ b/src/web_app/static/types.ts
@@ -1,5 +1,5 @@
 export interface ChatHistory {
-  role: string;
+  role: 'user' | 'assistant' | 'reviewer' | 'system';
   message: string;
 }
 

--- a/src/web_app/static/uploadForm.ts
+++ b/src/web_app/static/uploadForm.ts
@@ -59,9 +59,15 @@ export function renderDialog(
 ) {
   container.innerHTML = '';
   if (history && history.length) {
+    const roleClassMap: Record<ChatHistory['role'], string> = {
+      user: 'user',
+      assistant: 'assistant',
+      reviewer: 'reviewer',
+      system: 'system',
+    };
     history.forEach((msg) => {
       const div = document.createElement('div');
-      div.className = `ai-message ${msg.role === 'user' ? 'user' : 'assistant'}`;
+      div.className = `ai-message ${roleClassMap[msg.role]}`;
       div.textContent = msg.message;
       container.appendChild(div);
     });


### PR DESCRIPTION
## Summary
- restrict chat history roles to `user`, `assistant`, `reviewer` or `system`
- render AI history messages using role-specific classes
- handle new roles in chat modal

## Testing
- `npm_config_loglevel=error npx tsc`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c192a1cf908330acf412b6e175cb89