### PR TITLE
feat: extend upload response

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -72,3 +72,7 @@ class UploadResponse(BaseModel):
     raw_response: Any | None = None
     sources: Optional[List[str]] = None
     suggested_path: Optional[str] = None
+    chat_history: list[dict[str, Any]] = Field(default_factory=list)
+    review_comment: str | None = None
+    created_path: str | None = None
+    confirmed: bool | None = None

--- a/src/web_app/routes/files.py
+++ b/src/web_app/routes/files.py
@@ -485,7 +485,8 @@ async def regenerate_file(file_id: str, message: str | None = Body(None, embed=T
         missing=missing,
         suggested_path=str(dest_path),
     )
-    return await run_db(database.get_file, file_id)
+    record = await run_db(database.get_file, file_id)
+    return record.model_dump()
 
 
 @router.post("/files/{file_id}/comment", response_model=FileRecord)
@@ -545,4 +546,5 @@ async def comment_file(file_id: str, message: str = Body(..., embed=True)):
         suggested_path=str(dest_path),
         review_comment=message,
     )
-    return await run_db(database.get_file, file_id)
+    record = await run_db(database.get_file, file_id)
+    return record.model_dump()

--- a/src/web_app/routes/upload.py
+++ b/src/web_app/routes/upload.py
@@ -163,7 +163,11 @@ async def upload_file(
         prompt=meta_result.get("prompt"),
         raw_response=meta_result.get("raw_response"),
         suggested_path=str(dest_path),
-    )
+        chat_history=[],
+        review_comment=None,
+        created_path=None,
+        confirmed=None,
+    ).model_dump()
 
 
 @router.post("/upload/images", response_model=UploadResponse)
@@ -238,4 +242,8 @@ async def upload_images(
         prompt=meta_result.get("prompt"),
         raw_response=meta_result.get("raw_response"),
         suggested_path=str(dest_path),
-    )
+        chat_history=[],
+        review_comment=None,
+        created_path=None,
+        confirmed=None,
+    ).model_dump()


### PR DESCRIPTION
## Summary
- include chat and review data in upload response
- serialize new fields in upload and file routes

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c19e43381c8330924ac0ad1696af8c