### PR TITLE
feat: preview modal for batch uploads

### DIFF
--- a/src/web_app/static/dist/imageBatch.js
+++ b/src/web_app/static/dist/imageBatch.js
@@ -7,10 +7,8 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-import { refreshFiles } from './files.js';
-import { refreshFolderTree } from './folders.js';
 import { openImageEditModal } from './imageEditor.js';
-import { aiExchange, renderDialog } from './uploadForm.js';
+import { openPreviewModal, updateStep } from './uploadForm.js';
 export let currentImageIndex = -1;
 export let imageFiles = [];
 let fileInput;
@@ -62,6 +60,7 @@ export function uploadEditedImages() {
     return __awaiter(this, void 0, void 0, function* () {
         if (!imageFiles.length)
             return;
+        updateStep(1);
         const data = new FormData();
         imageFiles.forEach(f => {
             const file = new File([f.blob], f.name, { type: 'image/jpeg' });
@@ -69,16 +68,9 @@ export function uploadEditedImages() {
         });
         const resp = yield fetch('/upload/images', { method: 'POST', body: data });
         if (resp.ok) {
+            updateStep(2);
             const result = yield resp.json();
-            renderDialog(aiExchange, result.prompt, result.raw_response, result.chat_history, result.review_comment, result.created_path);
-            imageFiles = [];
-            currentImageIndex = -1;
-            fileInput.value = '';
-            imageBlock.style.display = 'none';
-            singleUploadBtn.style.display = '';
-            renderImageList();
-            refreshFiles();
-            refreshFolderTree();
+            openPreviewModal(result);
         }
         else {
             alert('Ошибка загрузки');

--- a/src/web_app/static/dist/uploadForm.js
+++ b/src/web_app/static/dist/uploadForm.js
@@ -40,7 +40,7 @@ const fieldMap = {
     'edit-new-name-translit': 'new_name_translit',
     'edit-needs-new-folder': 'needs_new_folder',
 };
-function updateStep(step) {
+export function updateStep(step) {
     currentStep = step;
     if (!stepIndicator)
         return;
@@ -462,7 +462,7 @@ export function setupUploadForm() {
         }
     });
 }
-function openPreviewModal(result) {
+export function openPreviewModal(result) {
     var _a;
     currentFile = result;
     currentId = result.id;

--- a/src/web_app/static/imageBatch.ts
+++ b/src/web_app/static/imageBatch.ts
@@ -1,8 +1,6 @@
-import { refreshFiles } from './files.js';
-import { refreshFolderTree } from './folders.js';
 import { openImageEditModal } from './imageEditor.js';
-import { aiExchange, renderDialog } from './uploadForm.js';
-import type { UploadResponse } from './types.js';
+import { openPreviewModal, updateStep } from './uploadForm.js';
+import type { UploadResponse, FileInfo } from './types.js';
 
 export let currentImageIndex = -1;
 export let imageFiles: Array<{ blob: Blob; name: string }> = [];
@@ -58,6 +56,7 @@ export function renderImageList() {
 
 export async function uploadEditedImages() {
   if (!imageFiles.length) return;
+  updateStep(1);
   const data = new FormData();
   imageFiles.forEach(f => {
     const file = new File([f.blob], f.name, { type: 'image/jpeg' });
@@ -65,23 +64,9 @@ export async function uploadEditedImages() {
   });
   const resp = await fetch('/upload/images', { method: 'POST', body: data });
   if (resp.ok) {
+    updateStep(2);
     const result: UploadResponse = await resp.json();
-    renderDialog(
-      aiExchange,
-      result.prompt,
-      result.raw_response,
-      result.chat_history,
-      result.review_comment,
-      result.created_path
-    );
-    imageFiles = [];
-    currentImageIndex = -1;
-    fileInput.value = '';
-    imageBlock.style.display = 'none';
-    singleUploadBtn.style.display = '';
-    renderImageList();
-    refreshFiles();
-    refreshFolderTree();
+    openPreviewModal(result as FileInfo);
   } else {
     alert('Ошибка загрузки');
   }

--- a/src/web_app/static/uploadForm.ts
+++ b/src/web_app/static/uploadForm.ts
@@ -34,7 +34,7 @@ const fieldMap: Record<string, string> = {
   'edit-needs-new-folder': 'needs_new_folder',
 };
 
-function updateStep(step: number) {
+export function updateStep(step: number) {
   currentStep = step;
   if (!stepIndicator) return;
   const steps = stepIndicator.querySelectorAll<HTMLElement>('.step');
@@ -471,7 +471,7 @@ export function setupUploadForm() {
   });
 }
 
-function openPreviewModal(result: FileInfo) {
+export function openPreviewModal(result: FileInfo) {
   currentFile = result;
   currentId = result.id;
   openMetadataModal(result);


### PR DESCRIPTION
## Summary
- show step indicator during batch image uploads
- open preview modal after successful upload instead of resetting

## Testing
- `npm test` (fails: Missing script: "test")
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c19f6d7a7c8330a3893c3193d6a6a6