### PR TITLE
feat: extend FileInfo with passport fields

### DIFF
--- a/src/web_app/static/dist/files.js
+++ b/src/web_app/static/dist/files.js
@@ -319,11 +319,13 @@ export function refreshFiles() {
     });
 }
 function populateMetadataForm(file) {
+    var _a;
     const m = file.metadata || {};
     editCategory.value = m.category || '';
     editSubcategory.value = m.subcategory || '';
     editIssuer.value = m.issuer || '';
-    editPerson && (editPerson.value = m.person || '');
+    const person = (_a = file.person) !== null && _a !== void 0 ? _a : m.person;
+    editPerson && (editPerson.value = person || '');
     editDocType && (editDocType.value = m.doc_type || '');
     editLanguage && (editLanguage.value = m.language || '');
     editNeedsFolder && (editNeedsFolder.checked = m.needs_new_folder || false);

--- a/src/web_app/static/dist/uploadForm.js
+++ b/src/web_app/static/dist/uploadForm.js
@@ -44,6 +44,7 @@ const fieldMap = {
     'edit-new-name-translit': 'new_name_translit',
     'edit-needs-new-folder': 'needs_new_folder',
 };
+const topLevelFields = ['person', 'date_of_birth', 'expiration_date', 'passport_number'];
 export function updateStep(step) {
     currentStep = step;
     if (!stepIndicator)
@@ -459,6 +460,9 @@ export function setupUploadForm() {
                             }
                             currentFile.metadata = currentFile.metadata || {};
                             currentFile.metadata[key] = suggested[key];
+                            if (topLevelFields.indexOf(key) !== -1) {
+                                currentFile[key] = suggested[key];
+                            }
                         }
                     });
                 }

--- a/src/web_app/static/files.ts
+++ b/src/web_app/static/files.ts
@@ -346,7 +346,8 @@ function populateMetadataForm(file: FileInfo) {
   editCategory.value = m.category || '';
   editSubcategory.value = m.subcategory || '';
   editIssuer.value = m.issuer || '';
-  editPerson && (editPerson.value = m.person || '');
+  const person = file.person ?? m.person;
+  editPerson && (editPerson.value = person || '');
   editDocType && (editDocType.value = m.doc_type || '');
   editLanguage && (editLanguage.value = m.language || '');
   editNeedsFolder && (editNeedsFolder.checked = m.needs_new_folder || false);

--- a/src/web_app/static/types.ts
+++ b/src/web_app/static/types.ts
@@ -39,6 +39,10 @@ export interface FileInfo {
   filename?: string;
   path?: string;
   metadata?: FileMetadata;
+  person?: string;
+  date_of_birth?: string;
+  expiration_date?: string;
+  passport_number?: string;
   tags_ru?: string[];
   tags_en?: string[];
   sources?: string[];

--- a/src/web_app/static/uploadForm.ts
+++ b/src/web_app/static/uploadForm.ts
@@ -38,6 +38,8 @@ const fieldMap: Record<string, string> = {
   'edit-needs-new-folder': 'needs_new_folder',
 };
 
+const topLevelFields = ['person', 'date_of_birth', 'expiration_date', 'passport_number'];
+
 export function updateStep(step: number) {
   currentStep = step;
   if (!stepIndicator) return;
@@ -460,6 +462,9 @@ export function setupUploadForm() {
               }
               currentFile!.metadata = currentFile!.metadata || {};
               (currentFile!.metadata as any)[key] = suggested[key];
+              if (topLevelFields.indexOf(key) !== -1) {
+                (currentFile as any)[key] = suggested[key];
+              }
             }
           });
         } catch {


### PR DESCRIPTION
## Summary
- expand FileInfo type with personal passport fields
- read person field from top-level FileInfo data
- keep top-level passport fields in sync when applying AI suggestions

## Testing
- `npx tsc`


------
https://chatgpt.com/codex/tasks/task_e_68c1a8994d0483308ce78483060af790